### PR TITLE
Use Facebook's graph properties to parse a page's most relevant photo. A 

### DIFF
--- a/lib/metainspector.rb
+++ b/lib/metainspector.rb
@@ -36,6 +36,12 @@ class MetaInspector
     @links ||= document.search("//a").map {|link| link.attributes["href"].to_s.strip} rescue nil
   end
   
+  # Returns the parsed image from Facebook's open graph property tags
+  # Most all major websites now define this property and is usually very relevant
+  def image
+    @image ||= document.css("meta[@property='og:image']").first['content'] rescue nil
+  end
+  
   # Returns the whole parsed document
   def document
     @document ||= Nokogiri::HTML(open(@address))


### PR DESCRIPTION
Use Facebook's graph properties to parse a page's most relevant photo. A majority of the web is now utilizing this property and would be a great addition to this gem. 
