### PR TITLE
Do not require `iconv`

### DIFF
--- a/lib/meta_inspector/scraper.rb
+++ b/lib/meta_inspector/scraper.rb
@@ -3,7 +3,6 @@
 require 'open-uri'
 require 'nokogiri'
 require 'charguess'
-require 'iconv'
 require 'hashie/rash'
 
 # MetaInspector provides an easy way to scrape web pages and get its elements


### PR DESCRIPTION
This suppresses deprecation warning thrown in 1.9.3
