### PR TITLE
Update dependency on Nokogiri

### DIFF
--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MetaInspector::VERSION
 
-  gem.add_dependency 'nokogiri', '1.5.3'
+  gem.add_dependency 'nokogiri', '~> 1.5'
   gem.add_dependency 'charguess', '1.3.20111021164500'
   gem.add_dependency 'rash', '0.3.2'
 


### PR DESCRIPTION
I'm using metainspector in a project where many other gems depend on Nokogiri also, but with a newer version (1.5.5 instead of 1.5.3).

I've updated the version of Nokogiri and all tests are OK.
