### PR TITLE
If url has no scheme, @host is nil

### DIFF
--- a/lib/meta_inspector/scraper.rb
+++ b/lib/meta_inspector/scraper.rb
@@ -14,8 +14,8 @@ module MetaInspector
 
     def initialize(url, timeout = 20)
       @url      = URI.parse(url).scheme.nil? ? 'http://' + url : url
-      @scheme   = URI.parse(url).scheme || 'http'
-      @host     = URI.parse(url).host
+      @scheme   = URI.parse(@url).scheme
+      @host     = URI.parse(@url).host
       @root_url = "#{@scheme}://#{@host}/"
       @timeout  = timeout
       @data     = Hashie::Rash.new('url' => @url)


### PR DESCRIPTION
If the URL is passed with no scheme we should use the new url with the http scheme to get the scheme and the host instance vars.

This change enables "cnn.com" as the url to return the correct host and scheme.
