### PR TITLE
Refactored meta tag ghost methods and added respond_to? to parser

### DIFF
--- a/lib/meta_inspector.rb
+++ b/lib/meta_inspector.rb
@@ -5,6 +5,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/excep
 require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/exception_log'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/request'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/url'))
+require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/meta_tags_dynamic_match'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/parser'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/document'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'meta_inspector/deprecations'))

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -39,7 +39,7 @@ module MetaInspector
     extend Forwardable
     def_delegators :@url,     :url, :scheme, :host, :root_url
     def_delegators :@request, :content_type
-    def_delegators :@parser,  :parsed, :method_missing, :title, :description, :links, :internal_links, :external_links,
+    def_delegators :@parser,  :parsed, :method_missing, :respond_to?, :title, :description, :links, :internal_links, :external_links,
                               :images, :image, :feed, :charset
 
     # Returns all document data as a nested Hash

--- a/lib/meta_inspector/meta_tags_dynamic_match.rb
+++ b/lib/meta_inspector/meta_tags_dynamic_match.rb
@@ -1,0 +1,18 @@
+module MetaInspector
+
+  # Encapsulates matching for method_missing and respond_to? for meta tags methods
+  class MetaTagsDynamicMatch
+    attr_reader :meta_tag
+
+    def initialize(method_name)
+      if method_name.to_s =~ /^meta_(.+)/
+        @meta_tag = $1
+      end
+    end
+
+    def match?
+      @meta_tag
+    end
+
+  end
+end

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -83,6 +83,10 @@ module MetaInspector
       @charset ||= (charset_from_meta_charset || charset_from_meta_content_type)
     end
 
+    def respond_to?(method_name, include_private = false)
+      MetaInspector::MetaTagsDynamicMatch.new(method_name).match? || super
+    end
+
     private
 
     def defaults
@@ -95,10 +99,11 @@ module MetaInspector
     #
     # It will first try with meta name="..." and if nothing found,
     # with meta http-equiv="...", substituting "_" by "-"
-    # TODO: define respond_to? to return true on the meta_name methods
     def method_missing(method_name)
-      if method_name.to_s =~ /^meta_(.*)/
-        key = $1
+      meta_tags_method = MetaInspector::MetaTagsDynamicMatch.new(method_name)
+
+      if meta_tags_method.match?
+        key = meta_tags_method.meta_tag
 
         #special treatment for opengraph (og:) and twitter card (twitter:) tags
         key.gsub!("_",":") if key =~ /^og_(.*)/ || key =~ /^twitter_(.*)/

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -267,6 +267,46 @@ describe MetaInspector::Parser do
     end
   end
 
+  describe 'respond_to? for meta tags ghost methods' do
+    before(:each) do
+      @m = MetaInspector.new('http://pagerankalert.com')
+    end
+
+    it "should return true for meta tags as string" do
+      @m.respond_to?("meta_robots").should be_true
+    end
+
+    it "should return true for meta tags as symbols" do
+      @m.respond_to?(:meta_robots).should be_true
+    end
+
+    it "should return true for meta_twitter_site as string" do
+      @m = MetaInspector.new('http://www.youtube.com/watch?v=iaGSSrp49uc')
+      @m.respond_to?("meta_twitter_site").should be_true
+    end
+
+    it "should return true for meta_twitter_site as symbol" do
+      @m = MetaInspector.new('http://www.youtube.com/watch?v=iaGSSrp49uc')
+      @m.respond_to?(:meta_twitter_player_width).should be_true
+    end
+  end
+
+  describe 'respond_to? for not implemented methods' do
+    
+    before(:each) do
+      @m = MetaInspector.new('http://pagerankalert.com')
+    end
+
+    it "should return false when method name passed as string" do
+      @m.respond_to?("method_not_implemented").should be_false
+    end
+
+    it "should return false when method name passed as symbols" do
+      @m = MetaInspector.new('http://www.youtube.com/watch?v=iaGSSrp49uc')
+      @m.respond_to?(:method_not_implemented).should be_false
+    end
+  end
+
   describe 'Getting meta tags by ghost methods' do
     before(:each) do
       @m = MetaInspector::Parser.new(doc 'http://pagerankalert.com')


### PR DESCRIPTION
- Refactored meta tag ghost method matching into a different class
- Added respond_to? using refactored class
- Changed method_missing to use refactored class
- Added spec test cases for respond_to? method
