### PR TITLE
make spec not dependent on network conditions

### DIFF
--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -44,6 +44,7 @@ describe MetaInspector::Request do
     end
 
     it "should handle socket errors" do
+      TCPSocket.stub(:open).and_raise(SocketError)
       logger.should receive(:<<).with(an_instance_of(SocketError))
 
       MetaInspector::Request.new(url('http://caca232dsdsaer3sdsd-asd343.org'), exception_log: logger)


### PR DESCRIPTION
fixes #66

on a host system that resolves unknown domain names to a "helpful" search, this test will fail because there will never be a socket error. This change fixes that.

![screen shot 2014-08-08 at 11 26 40 am](https://cloud.githubusercontent.com/assets/6097/3858698/7eccddee-1f10-11e4-87fb-c946c5ce1f09.png)
![screen shot 2014-08-08 at 11 27 11 am](https://cloud.githubusercontent.com/assets/6097/3858699/7ed61eea-1f10-11e4-8896-2e01412ccc27.png)
