### PR TITLE
Use faraday instead of raw net/http

### DIFF
--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -66,7 +66,8 @@ module MetaInspector
       { :timeout => 20,
         :html_content_only => false,
         :warn_level => :raise,
-        :headers => {'User-Agent' => "MetaInspector/#{MetaInspector::VERSION} (+https://github.com/jaimeiniesta/metainspector)"}
+        :headers => {'User-Agent' => "MetaInspector/#{MetaInspector::VERSION} (+https://github.com/jaimeiniesta/metainspector)"},
+        :allow_redirections => true
       }
     end
 

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-require 'open-uri'
-require 'open_uri_redirections'
+require 'faraday'
+require 'faraday_middleware'
 require 'timeout'
 
 module MetaInspector
@@ -15,15 +15,7 @@ module MetaInspector
 
       @url                = initial_url
       
-      @allow_redirections = case options[:allow_redirections]
-        when nil, true
-          :all
-        when false
-          nil
-        else
-          raise ArgumentError, "invalid option for allow_redirections. must be true or false"
-        end
-      
+      @allow_redirections = options[:allow_redirections]
       @timeout            = options[:timeout]
       @exception_log      = options[:exception_log]
       @headers            = options[:headers]
@@ -35,37 +27,39 @@ module MetaInspector
     def_delegators :@url, :url
 
     def read
-      response.read if response
+      response.body if response
     end
 
     def content_type
-      response.content_type if response
+      response.headers["content-type"].split(";")[0] if response
     end
 
     private
 
     def response
       Timeout::timeout(@timeout) { @response ||= fetch }
-    rescue TimeoutError, SocketError, RuntimeError => e
+    rescue TimeoutError, Faraday::ConnectionFailed, RuntimeError => e
       @exception_log << e
       nil
     end
 
     def fetch
-      options = {}
-        
-      options.merge!(:allow_redirections => @allow_redirections) if @allow_redirections
-      options.merge!(@headers)                                   if @headers.is_a?(Hash)
+      session = Faraday.new(:url => url) do |faraday|
+        if @allow_redirections
+          faraday.use FaradayMiddleware::FollowRedirects, limit: 10
+        end
+        faraday.headers.merge!(@headers || {})
+        faraday.adapter :net_http
+      end
+      response = session.get
 
-      request = open(url, options)
+      @url.url = response.env.url.to_s
 
-      @url.url = request.base_uri.to_s
-
-      request
+      response
     end
 
     def defaults
-      { timeout: 20, exception_log: MetaInspector::ExceptionLog.new }
+      { timeout: 20, exception_log: MetaInspector::ExceptionLog.new, allow_redirections: true }
     end
   end
 end

--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |gem|
   gem.version       = MetaInspector::VERSION
 
   gem.add_dependency 'nokogiri', '~> 1.6'
-  gem.add_dependency 'open_uri_redirections', '~> 0.1.4'
+  gem.add_dependency 'faraday'
+  gem.add_dependency 'faraday_middleware'
   gem.add_dependency 'addressable', '~> 2.3.5'
 
   gem.add_development_dependency 'rspec', '2.14.1'

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -93,26 +93,22 @@ describe MetaInspector::Document do
 
   describe 'headers' do
     it "should include default headers" do
-      url     = 'http://example.com/headers'
-      request = double('Request', base_uri: url)
-      expected_headers = {:allow_redirections => :all, 'User-Agent' => "MetaInspector/#{MetaInspector::VERSION} (+https://github.com/jaimeiniesta/metainspector)"}
-
-      MetaInspector::Request.any_instance.should_receive(:open)
-                                         .with(url, expected_headers)
-                                         .and_return(request)
-
+      url = "http://pagerankalert.com/"
+      expected_headers = {'User-Agent' => "MetaInspector/#{MetaInspector::VERSION} (+https://github.com/jaimeiniesta/metainspector)"}
+                                         
+      headers = {}
+      headers.should_receive(:merge!).with(expected_headers)
+      Faraday::Connection.any_instance.stub(:headers){headers}
       MetaInspector::Document.new(url)
     end
 
     it "should include passed headers on the request" do
-      url     = 'http://example.com/headers'
-      headers = {:allow_redirections => :all, 'User-Agent' => 'Mozilla', 'Referer' => 'https://github.com/'}
-      request = double('Request', base_uri: url)
+      url = "http://pagerankalert.com/"
+      headers = {'User-Agent' => 'Mozilla', 'Referer' => 'https://github.com/'}
 
-      MetaInspector::Request.any_instance.should_receive(:open)
-                                         .with(url, headers)
-                                         .and_return(request)
-
+      headers = {}
+      headers.should_receive(:merge!).with(headers)
+      Faraday::Connection.any_instance.stub(:headers){headers}
       MetaInspector::Document.new(url, headers: headers)
     end
   end

--- a/spec/redirections_spec.rb
+++ b/spec/redirections_spec.rb
@@ -8,9 +8,8 @@ describe MetaInspector do
 
     context "when redirecitons are turned off" do
       it "disallows redirections" do
-        logger.should receive(:<<).with(an_instance_of(RuntimeError))
-
-        MetaInspector.new("http://facebook.com", :allow_redirections => false, exception_log: logger)
+        m = MetaInspector.new("http://facebook.com", :allow_redirections => false, exception_log: logger)
+        m.url.should == "http://facebook.com/"
       end
     end
 
@@ -27,14 +26,6 @@ describe MetaInspector do
         m = MetaInspector.new("http://facebook.com")
 
         m.url.should == "https://www.facebook.com/"
-      end
-    end
-
-    context "when allow_redirections is not given a boolean" do
-      it "raises an error" do
-        expect{
-          MetaInspector.new("http://facebook.com", :allow_redirections => :hello, exception_log: logger)
-        }.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -45,7 +45,7 @@ describe MetaInspector::Request do
 
     it "should handle socket errors" do
       TCPSocket.stub(:open).and_raise(SocketError)
-      logger.should receive(:<<).with(an_instance_of(SocketError))
+      logger.should receive(:<<).with(an_instance_of(Faraday::ConnectionFailed))
 
       MetaInspector::Request.new(url('http://caca232dsdsaer3sdsd-asd343.org'), exception_log: logger)
     end


### PR DESCRIPTION
I decided to go with Faraday instead of Typhoeus
- faraday uses net/http, so it doesn't introduce as many new dependencies as typhoeus, which uses libcurl and ffi.
- fakeweb can only test net/http, so it would have taken an enormous amount of refactoring in order to move the test suite to work with typhoeus
- in general i have grown to like faraday's approach
