### PR TITLE
Timeout retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,30 @@ And the full scraped document is accessible from:
 
 ## Options
 
-### Timeout
+### Timeout & Retries
 
-By default, MetaInspector times out after 20 seconds of waiting for a page to respond.
-You can set a different timeout with a second parameter, like this:
+By default, MetaInspector times out after 20 seconds of waiting for a page to respond,
+and it will retry fetching the page 3 times.
+You can specify different values for both of these, like this:
 
-    page = MetaInspector.new('sitevalidator.com', :timeout => 5) # 5 seconds timeout
+    # timeout after 5 seconds, retry 4 times
+    page = MetaInspector.new('sitevalidator.com', :timeout => 5, :retries => 4)
+
+If MetaInspector fails to fetch the page after it has exhausted its retries,
+it will raise `MetaInspector::Request::TimeoutError`, which you can rescue in your
+application code.
+
+    begin
+      data = MetaInspector.new(url)
+    rescue MetaInspector::Request::TimeoutError
+      enqueue_for_future_fetch_attempt(url)
+      render_simple(url)
+    rescue
+      log_fetch_error($!)
+      render_simple(url)
+    else
+      render_rich(data)
+    end
 
 ### Redirections
 

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -64,6 +64,7 @@ module MetaInspector
 
     def defaults
       { :timeout => 20,
+        :retries => 3,
         :html_content_only => false,
         :warn_level => :raise,
         :headers => {'User-Agent' => "MetaInspector/#{MetaInspector::VERSION} (+https://github.com/jaimeiniesta/metainspector)"},


### PR DESCRIPTION
as discussed in #89 

new features:
- Retries (hardcoded at 3). my gut is to leave this as it is unless people request that it be made adjustable. i suppose if someone is commonly scraping a really flakey source they might want to increase this, or if someone doesn't want to ever be forgiving they might want to decrease it.
- raises MetaInspector::Request::TimeoutError after 3 failures, which the application can then catch and deal with.

MetaInspector::Request::TimeoutError has the same name as the legacy name for Timeout::Error, but this still works, and in fact that is the reason that Timeout::TimeoutError was renamed (I'm guessing), so that meaningful classes such as this would could be made.
