### PR TITLE
Improved page.image method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can see the scraped data like this:
     page.meta['keywords']    # meta keywords, as string
     page.meta['description'] # meta description, as string
     page.description         # returns the meta description, or the first long paragraph if no meta description is found
-    page.image               # Most relevant image, if defined with the og:image meta tag
+    page.image               # Most relevant image, if defined with the og:image or twitter:image metatags. Fallback to the first page.images array element
     page.images              # array of strings, with every img found on the page as an absolute URL
     page.feed                # Get rss or atom links in meta data fields as array
     page.charset             # UTF-8

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -85,9 +85,8 @@ module MetaInspector
     # Most all major websites now define this property and is usually very relevant
     # See doc at http://developers.facebook.com/docs/opengraph/
     # If none found, tries with Twitter image
-    # TODO: if not found, try with images.first
     def image
-      meta['og:image'] || meta['twitter:image']
+      meta['og:image'] || meta['twitter:image'] || images.first
     end
 
     # Returns the parsed document meta rss link

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -11,10 +11,6 @@ describe MetaInspector::Parser do
       @m = MetaInspector::Parser.new(doc 'http://pagerankalert.com')
     end
 
-    it "should not find an image" do
-      @m.image.should == nil
-    end
-
     describe "get image" do
       it "should find the og image" do
         @m = MetaInspector::Parser.new(doc 'http://www.theonion.com/articles/apple-claims-new-iphone-only-visible-to-most-loyal,2772/')
@@ -23,6 +19,10 @@ describe MetaInspector::Parser do
 
       it "should find image on youtube" do
         MetaInspector::Parser.new(doc 'http://www.youtube.com/watch?v=iaGSSrp49uc').image.should == "http://i2.ytimg.com/vi/iaGSSrp49uc/mqdefault.jpg"
+      end
+
+      it "should find image when og:image and twitter:image metatags are missing" do
+        MetaInspector::Parser.new(doc 'http://www.alazan.com').image.should == "http://www.alazan.com/imagenes/logo.jpg"
       end
     end
 


### PR DESCRIPTION
Now **page.image** gives always the first element in **page.images**

``` ruby
page = MetaInspector.new 'https://twitter.com/astro_reid/status/527799661823008768'
page.image # https://pbs.twimg.com/profile_images/1431054149/image_bigger.jpg
```

With this change, its easier to get images from URLs.

Hope you like it :smile: 
