### PR TITLE
[WIP] passing control of timeouts to Faraday

### DIFF
--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -1,13 +1,15 @@
 module MetaInspector
   # A MetaInspector::Document knows about its URL and its contents
   class Document
-    attr_reader :timeout, :html_content_only, :allow_redirections, :warn_level, :headers
+    attr_reader :html_content_only, :allow_redirections, :warn_level, :headers
 
     include MetaInspector::Exceptionable
 
     # Initializes a new instance of MetaInspector::Document, setting the URL to the one given
     # Options:
-    # => timeout: defaults to 20 seconds
+    # => connection_timeout: defaults to 20 seconds
+    # => read_timeout: defaults to 20 seconds
+    # => retries: defaults to 3 times
     # => html_content_type_only: if an exception should be raised if request content-type is not text/html. Defaults to false
     # => allow_redirections: when true, follow HTTP redirects. Defaults to true
     # => document: the html of the url as a string
@@ -15,7 +17,9 @@ module MetaInspector
     # => headers: object containing custom headers for the request
     def initialize(initial_url, options = {})
       options             = defaults.merge(options)
-      @timeout            = options[:timeout]
+      @connection_timeout = options[:connection_timeout]
+      @read_timeout       = options[:read_timeout]
+      @retries            = options[:retries]
       @html_content_only  = options[:html_content_only]
       @allow_redirections = options[:allow_redirections]
       @document           = options[:document]
@@ -24,7 +28,9 @@ module MetaInspector
       @exception_log      = options[:exception_log] || MetaInspector::ExceptionLog.new(warn_level: warn_level)
       @url                = MetaInspector::URL.new(initial_url, exception_log: @exception_log)
       @request            = MetaInspector::Request.new(@url,  allow_redirections: @allow_redirections,
-                                                              timeout:            @timeout,
+                                                              connection_timeout: @connection_timeout,
+                                                              read_timeout:       @read_timeout,
+                                                              retries:            @retries,
                                                               exception_log:      @exception_log,
                                                               headers:            @headers) unless @document
       @parser             = MetaInspector::Parser.new(self,  exception_log:      @exception_log)

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -1,7 +1,6 @@
 require 'faraday'
 require 'faraday_middleware'
 require 'faraday-cookie_jar'
-require 'timeout'
 
 module MetaInspector
 
@@ -13,7 +12,8 @@ module MetaInspector
       @url                = initial_url
 
       @allow_redirections = options[:allow_redirections]
-      @timeout            = options[:timeout]
+      @connection_timeout = options[:connection_timeout]
+      @read_timeout       = options[:read_timeout]
       @retries            = options[:retries]
       @exception_log      = options[:exception_log]
       @headers            = options[:headers]
@@ -35,11 +35,8 @@ module MetaInspector
     def response
       request_count ||= 0
       request_count += 1
-      Timeout::timeout(@timeout) { @response ||= fetch }
-    rescue Timeout::Error
-      retry unless @retries == request_count
-      @exception_log << TimeoutError.new("Attempt to fetch #{url} timed out 3 times.")
-    rescue Faraday::Error::ConnectionFailed, RuntimeError => e
+      @response ||= fetch
+    rescue Faraday::TimeoutError, Faraday::Error::ConnectionFailed, RuntimeError => e
       @exception_log << e
       nil
     end
@@ -48,21 +45,25 @@ module MetaInspector
 
     def fetch
       session = Faraday.new(:url => url) do |faraday|
+        faraday.request :retry, max: @retries
+
         if @allow_redirections
           faraday.use FaradayMiddleware::FollowRedirects, limit: 10
           faraday.use :cookie_jar
         end
+
         faraday.headers.merge!(@headers || {})
         faraday.adapter :net_http
       end
-      response = session.get
+
+      response = session.get do |req|
+        req.options.timeout      = @connection_timeout
+        req.options.open_timeout = @read_timeout
+      end
 
       @url.url = response.env.url.to_s
 
       response
-    end
-
-    class TimeoutError < StandardError
     end
   end
 end

--- a/lib/meta_inspector/version.rb
+++ b/lib/meta_inspector/version.rb
@@ -1,3 +1,3 @@
 module MetaInspector
-  VERSION = "4.0.0.rc2"
+  VERSION = "4.0.0.rc3"
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -60,50 +60,6 @@ describe MetaInspector::Request do
     end
   end
 
-  describe "retrying on timeouts" do
-    let(:logger) { MetaInspector::ExceptionLog.new }
-    subject do
-      MetaInspector::Request.new(url('http://pagerankalert.com'),
-                                 exception_log: logger, retries: 3)
-     end
-
-    context "when request never succeeds" do
-      before{ Timeout.stub(:timeout).and_raise(Timeout::Error) }
-      it "swallows all the timeout errors and raises MetaInspector::Request::TimeoutError" do
-        logger.should receive(:<<).with(an_instance_of(MetaInspector::Request::TimeoutError))
-        subject
-      end
-    end
-
-    context "when request succeeds on third try" do
-      before do
-        Timeout.stub(:timeout).and_raise(Timeout::Error)
-        Timeout.stub(:timeout).and_raise(Timeout::Error)
-        Timeout.stub(:timeout).and_call_original
-      end
-      it "doesn't raise an exception" do
-        logger.should_not receive(:<<)
-        subject
-      end
-      it "succeeds as normal" do
-        subject.content_type.should == "text/html"
-      end
-    end
-
-    context "when request succeeds on fourth try" do
-      before do
-        Timeout.stub(:timeout).exactly(3).times.and_raise(Timeout::Error)
-        # if it were called a fourth time, rspec would raise an error
-        # so this implicitely tests the correct behavior
-      end
-      it "swallows all the timeout errors and raises MetaInspector::Request::TimeoutError" do
-        logger.should receive(:<<).with(an_instance_of(MetaInspector::Request::TimeoutError))
-        subject
-      end
-    end
-
-  end
-
   private
 
   def url(initial_url)


### PR DESCRIPTION
Regarding #107 we should move the timeout control to Faraday itself. 

This is still a work in progress, I still want to:
- [x] Make use of the 2 different timeouts that Faraday accepts (connection and read).
- [x] Use the [retry mechanism](https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb) provided by Faraday.
