### PR TITLE
Add normalize_url option

### DIFF
--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -28,7 +28,9 @@ module MetaInspector
       @headers            = options[:headers]
       @warn_level         = options[:warn_level]
       @exception_log      = options[:exception_log] || MetaInspector::ExceptionLog.new(warn_level: warn_level)
-      @url                = MetaInspector::URL.new(initial_url, exception_log: @exception_log)
+      @normalize_url      = options[:normalize_url]
+      @url                = MetaInspector::URL.new(initial_url, exception_log: @exception_log,
+                                                                normalize: @normalize_url)
       @request            = MetaInspector::Request.new(@url,  allow_redirections: @allow_redirections,
                                                               connection_timeout: @connection_timeout,
                                                               read_timeout:       @read_timeout,
@@ -77,7 +79,8 @@ module MetaInspector
         :html_content_only  => false,
         :warn_level         => :raise,
         :headers            => { 'User-Agent' => default_user_agent },
-        :allow_redirections => true }
+        :allow_redirections => true,
+        :normalize_url      => true }
     end
 
     def default_user_agent

--- a/lib/meta_inspector/url.rb
+++ b/lib/meta_inspector/url.rb
@@ -7,7 +7,9 @@ module MetaInspector
     include MetaInspector::Exceptionable
 
     def initialize(initial_url, options = {})
+      options        = { :normalize => true }.merge(options)
       @exception_log = options[:exception_log]
+      @normalize     = options[:normalize]
 
       self.url = initial_url
     end
@@ -25,7 +27,8 @@ module MetaInspector
     end
 
     def url=(new_url)
-      @url = normalized(with_default_scheme(new_url))
+      url = with_default_scheme(new_url)
+      @url = @normalize ? normalized(url) : url
     end
 
     # Converts a protocol-relative url to its full form,

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -171,4 +171,14 @@ describe MetaInspector::Document do
       MetaInspector::Document.new(url, headers: headers)
     end
   end
+
+  describe 'url' do
+    it 'should normalize' do
+      MetaInspector.new('http://example.com/%EF%BD%9E').url.should == 'http://example.com/~'
+    end
+
+    it 'should not normalize' do
+      MetaInspector.new('http://example.com/%EF%BD%9E', normalize_url: false).url.should == 'http://example.com/%EF%BD%9E'
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,3 +79,8 @@ FakeWeb.register_uri(:get, "https://www.facebook.com/",     :response => fixture
 # https://unsafe-facebook.com => http://unsafe-facebook.com
 FakeWeb.register_uri(:get, "https://unsafe-facebook.com/",  :response => fixture_file("unsafe_https.facebook.com.response"))
 FakeWeb.register_uri(:get, "http://unsafe-facebook.com/",   :response => fixture_file("unsafe_facebook.com.response"))
+
+# These examples are used to test normalize URLs
+FakeWeb.register_uri(:get, "http://example.com/%EF%BD%9E", :response => fixture_file("example.response"))
+FakeWeb.register_uri(:get, "http://example.com/~", :response => fixture_file("example.response"))
+


### PR DESCRIPTION
ref: #110

metainspector can't access This page.

[Template:～ - Wikipedia](http://ja.wikipedia.org/wiki/Template:%EF%BD%9E)

But, another HTTP Client can access it.

```ruby
require 'metainspector'
require 'open-uri'
require 'httpclient'
require 'faraday'

url = 'http://ja.wikipedia.org/wiki/Template:%EF%BD%9E'

# metainspector
puts MetaInspector.new(url).response.status #=> 404

# open-uri
puts open(url).status #=> 200

# httpclient
puts HTTPClient.new.get(url).status #=> 200

# faraday
puts Faraday.new(url).get.status #=> 200
```

This issue is caused URL normalization. This patch allows you to disable URL normalization by option.

```ruby
MetaInspector.new(url, normalize_url: false)
```