### PR TITLE
Upgrade RSpec to 3.0

### DIFF
--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'addressable', '~> 2.3.5'
   gem.add_dependency 'fastimage'
 
-  gem.add_development_dependency 'rspec', '2.14.1'
+  gem.add_development_dependency 'rspec', '2.99.0'
   gem.add_development_dependency 'fakeweb', '1.3.0'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'awesome_print'

--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'addressable', '~> 2.3.5'
   gem.add_dependency 'fastimage'
 
-  gem.add_development_dependency 'rspec', '2.99.0'
+  gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'fakeweb', '1.3.0'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'awesome_print'

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -5,21 +5,21 @@ describe MetaInspector::Document do
     let(:doc) { MetaInspector::Document.new('http://cnn.com/', :document => "<html><head><title>Hello From Passed Html</title><a href='/hello'>Hello link</a></head><body></body></html>") }
 
     it "should get correct links when the url html is passed as an option" do
-      doc.links.internal.should == ["http://cnn.com/hello"]
+      expect(doc.links.internal).to eq(["http://cnn.com/hello"])
     end
 
     it "should get the title" do
-      doc.title.should == "Hello From Passed Html"
+      expect(doc.title).to eq("Hello From Passed Html")
     end
   end
 
   it "should return a String as to_s" do
-    MetaInspector::Document.new('http://pagerankalert.com').to_s.class.should == String
+    expect(MetaInspector::Document.new('http://pagerankalert.com').to_s.class).to eq(String)
   end
 
   it "should return a Hash with all the values set" do
     doc = MetaInspector::Document.new('http://pagerankalert.com')
-    doc.to_hash.should == {
+    expect(doc.to_hash).to eq({
                             "url"             => "http://pagerankalert.com/",
                             "scheme"          => "http",
                             "host"            => "pagerankalert.com",
@@ -71,28 +71,28 @@ describe MetaInspector::Document do
                                                                   "via" => "1.1 varnish"
                                                                 }
                                                  }
-                         }
+                         })
   end
 
   describe 'exception handling' do
     let(:logger) { MetaInspector::ExceptionLog.new }
 
     it "should parse images when parse_html_content_type_only is not specified" do
-      logger.should_not receive(:<<)
+      expect(logger).not_to receive(:<<)
 
       image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png', exception_log: logger)
       image_url.title
     end
 
     it "should parse images when parse_html_content_type_only is false" do
-      logger.should_not receive(:<<)
+      expect(logger).not_to receive(:<<)
 
       image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png', html_content_only: false, exception_log: logger)
       image_url.title
     end
 
     it "should handle errors when content is image/jpeg and html_content_type_only is true" do
-      logger.should_receive(:<<).with(an_instance_of(RuntimeError))
+      expect(logger).to receive(:<<).with(an_instance_of(RuntimeError))
 
       image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png', html_content_only: true, exception_log: logger)
 
@@ -100,7 +100,7 @@ describe MetaInspector::Document do
     end
 
     it "should handle errors when content is not text/html and html_content_type_only is true" do
-      logger.should_receive(:<<).with(an_instance_of(RuntimeError))
+      expect(logger).to receive(:<<).with(an_instance_of(RuntimeError))
 
       tar_url = MetaInspector::Document.new('http://pagerankalert.com/file.tar.gz', html_content_only: true, exception_log: logger)
 
@@ -114,11 +114,11 @@ describe MetaInspector::Document do
       end
 
       it 'stores the exceptions' do
-        @bad_request.exceptions.should_not be_empty
+        expect(@bad_request.exceptions).not_to be_empty
       end
 
       it 'makes ok? to return false' do
-        @bad_request.should_not be_ok
+        expect(@bad_request).not_to be_ok
       end
     end
 
@@ -136,7 +136,7 @@ describe MetaInspector::Document do
         bad_request.title
 
         $stderr.rewind
-        $stderr.string.chomp.should eq("The url provided contains image/png content instead of text/html content")
+        expect($stderr.string.chomp).to eq("The url provided contains image/png content instead of text/html content")
       end
 
       it 'does not raise an exception' do
@@ -161,8 +161,8 @@ describe MetaInspector::Document do
       expected_headers = {'User-Agent' => "MetaInspector/#{MetaInspector::VERSION} (+https://github.com/jaimeiniesta/metainspector)"}
 
       headers = {}
-      headers.should_receive(:merge!).with(expected_headers)
-      Faraday::Connection.any_instance.stub(:headers){headers}
+      expect(headers).to receive(:merge!).with(expected_headers)
+      allow_any_instance_of(Faraday::Connection).to receive(:headers){headers}
       MetaInspector::Document.new(url)
     end
 
@@ -171,19 +171,19 @@ describe MetaInspector::Document do
       headers = {'User-Agent' => 'Mozilla', 'Referer' => 'https://github.com/'}
 
       headers = {}
-      headers.should_receive(:merge!).with(headers)
-      Faraday::Connection.any_instance.stub(:headers){headers}
+      expect(headers).to receive(:merge!).with(headers)
+      allow_any_instance_of(Faraday::Connection).to receive(:headers){headers}
       MetaInspector::Document.new(url, headers: headers)
     end
   end
 
   describe 'url normalization' do
     it 'should normalize by default' do
-      MetaInspector.new('http://example.com/%EF%BD%9E').url.should == 'http://example.com/~'
+      expect(MetaInspector.new('http://example.com/%EF%BD%9E').url).to eq('http://example.com/~')
     end
 
     it 'should not normalize if the normalize_url option is false' do
-      MetaInspector.new('http://example.com/%EF%BD%9E', normalize_url: false).url.should == 'http://example.com/%EF%BD%9E'
+      expect(MetaInspector.new('http://example.com/%EF%BD%9E', normalize_url: false).url).to eq('http://example.com/%EF%BD%9E')
     end
   end
 end

--- a/spec/exception_log_spec.rb
+++ b/spec/exception_log_spec.rb
@@ -4,7 +4,7 @@ describe MetaInspector::ExceptionLog do
 
   describe "warn_level" do
     it "should be :raise by default" do
-      MetaInspector::ExceptionLog.new.warn_level.should == :raise
+      expect(MetaInspector::ExceptionLog.new.warn_level).to eq(:raise)
     end
 
     it "should raise exceptions when warn_level is :raise" do
@@ -20,7 +20,7 @@ describe MetaInspector::ExceptionLog do
       logger    = MetaInspector::ExceptionLog.new(warn_level: :warn)
       exception = StandardError.new("an error message")
 
-      logger.should_receive(:warn).with(exception)
+      expect(logger).to receive(:warn).with(exception)
       logger << exception
     end
 
@@ -49,28 +49,28 @@ describe MetaInspector::ExceptionLog do
       logger << first
       logger << second
 
-      logger.exceptions.should == [first, second]
+      expect(logger.exceptions).to eq([first, second])
     end
 
     describe "ok?" do
       it "should be true if no exceptions stored" do
-        logger.should be_ok
+        expect(logger).to be_ok
       end
 
       it "should be false if some exception stored" do
         logger << StandardError.new("some message")
-        logger.should_not be_ok
+        expect(logger).not_to be_ok
       end
 
       it "should warn about misuse if warn_level is :raise" do
         logger    = MetaInspector::ExceptionLog.new(warn_level: :raise)
-        logger.should_receive(:warn).with("ExceptionLog#ok? should only be used when warn_level is :store")
+        expect(logger).to receive(:warn).with("ExceptionLog#ok? should only be used when warn_level is :store")
         logger.ok?
       end
 
       it "should warn about misuse if warn_level is :warn" do
         logger    = MetaInspector::ExceptionLog.new(warn_level: :warn)
-        logger.should_receive(:warn).with("ExceptionLog#ok? should only be used when warn_level is :store")
+        expect(logger).to receive(:warn).with("ExceptionLog#ok? should only be used when warn_level is :store")
         logger.ok?
       end
     end

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -7,39 +7,39 @@ describe MetaInspector do
       let(:page) { MetaInspector.new('https://twitter.com/markupvalidator') }
 
       it "responds to #length" do
-        page.images.length.should == 6
+        expect(page.images.length).to eq(6)
       end
 
       it "responds to #size" do
-        page.images.size.should == 6
+        expect(page.images.size).to eq(6)
       end
 
       it "responds to #each" do
         c = []
         page.images.each {|i| c << i}
-        c.length.should == 6
+        expect(c.length).to eq(6)
       end
 
       it "responds to #sort" do
-        page.images.sort
-          .should == ["https://si0.twimg.com/sticky/default_profile_images/default_profile_6_mini.png",
+        expect(page.images.sort)
+          .to eq(["https://si0.twimg.com/sticky/default_profile_images/default_profile_6_mini.png",
                       "https://twimg0-a.akamaihd.net/a/1342841381/images/bigger_spinner.gif",
                       "https://twimg0-a.akamaihd.net/profile_images/1538528659/jaime_nov_08_normal.jpg",
                       "https://twimg0-a.akamaihd.net/profile_images/2293774732/v0pgo4xpdd9rou2xq5h0_normal.png",
                       "https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_normal.png",
-                      "https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png"]
+                      "https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png"])
       end
 
       it "responds to #first" do
-        page.images.first.should == "https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png"
+        expect(page.images.first).to eq("https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png")
       end
 
       it "responds to #last" do
-        page.images.last.should == "https://twimg0-a.akamaihd.net/a/1342841381/images/bigger_spinner.gif"
+        expect(page.images.last).to eq("https://twimg0-a.akamaihd.net/a/1342841381/images/bigger_spinner.gif")
       end
 
       it "responds to #[]" do
-        page.images[0].should == "https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png"
+        expect(page.images[0]).to eq("https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png")
       end
 
     end
@@ -47,26 +47,26 @@ describe MetaInspector do
     it "should find all page images" do
       page = MetaInspector.new('http://pagerankalert.com')
 
-      page.images.to_a.should == ["http://pagerankalert.com/images/pagerank_alert.png?1305794559"]
+      expect(page.images.to_a).to eq(["http://pagerankalert.com/images/pagerank_alert.png?1305794559"])
     end
 
     it "should find images on twitter" do
       page = MetaInspector.new('https://twitter.com/markupvalidator')
 
-      page.images.length.should == 6
-      page.images.to_a.should == ["https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png",
+      expect(page.images.length).to eq(6)
+      expect(page.images.to_a).to eq(["https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_reasonably_small.png",
                              "https://twimg0-a.akamaihd.net/profile_images/2380086215/fcu46ozay5f5al9kdfvq_normal.png",
                              "https://twimg0-a.akamaihd.net/profile_images/2293774732/v0pgo4xpdd9rou2xq5h0_normal.png",
                              "https://twimg0-a.akamaihd.net/profile_images/1538528659/jaime_nov_08_normal.jpg",
                              "https://si0.twimg.com/sticky/default_profile_images/default_profile_6_mini.png",
-                             "https://twimg0-a.akamaihd.net/a/1342841381/images/bigger_spinner.gif"]
+                             "https://twimg0-a.akamaihd.net/a/1342841381/images/bigger_spinner.gif"])
     end
 
     it "should ignore malformed image tags" do
       # There is an image tag without a source. The scraper should not fatal.
       page = MetaInspector.new("http://www.guardian.co.uk/media/pda/2011/sep/15/techcrunch-arrington-startups")
 
-      page.images.size.should == 11
+      expect(page.images.size).to eq(11)
     end
   end
 
@@ -74,19 +74,19 @@ describe MetaInspector do
     it "should find the og image" do
       page = MetaInspector.new('http://www.theonion.com/articles/apple-claims-new-iphone-only-visible-to-most-loyal,2772/')
 
-      page.images.best.should == "http://o.onionstatic.com/images/articles/article/2772/Apple-Claims-600w-R_jpg_130x110_q85.jpg"
+      expect(page.images.best).to eq("http://o.onionstatic.com/images/articles/article/2772/Apple-Claims-600w-R_jpg_130x110_q85.jpg")
     end
 
     it "should find image on youtube" do
       page = MetaInspector.new('http://www.youtube.com/watch?v=iaGSSrp49uc')
 
-      page.images.best.should == "http://i2.ytimg.com/vi/iaGSSrp49uc/mqdefault.jpg"
+      expect(page.images.best).to eq("http://i2.ytimg.com/vi/iaGSSrp49uc/mqdefault.jpg")
     end
 
     it "should find image when og:image and twitter:image metatags are missing" do
       page = MetaInspector.new('http://example.com/largest_image_using_image_size')
 
-      page.images.best.should == "http://example.com/100x100"
+      expect(page.images.best).to eq("http://example.com/100x100")
     end
   end
 
@@ -94,19 +94,19 @@ describe MetaInspector do
     it "should find the og image" do
       page = MetaInspector.new('http://www.theonion.com/articles/apple-claims-new-iphone-only-visible-to-most-loyal,2772/')
 
-      page.images.owner_suggested.should == "http://o.onionstatic.com/images/articles/article/2772/Apple-Claims-600w-R_jpg_130x110_q85.jpg"
+      expect(page.images.owner_suggested).to eq("http://o.onionstatic.com/images/articles/article/2772/Apple-Claims-600w-R_jpg_130x110_q85.jpg")
     end
 
     it "should find image on youtube" do
       page = MetaInspector.new('http://www.youtube.com/watch?v=iaGSSrp49uc')
 
-      page.images.owner_suggested.should == "http://i2.ytimg.com/vi/iaGSSrp49uc/mqdefault.jpg"
+      expect(page.images.owner_suggested).to eq("http://i2.ytimg.com/vi/iaGSSrp49uc/mqdefault.jpg")
     end
 
     it "should return nil when og:image and twitter:image metatags are missing" do
       page = MetaInspector.new('http://example.com/largest_image_using_image_size')
 
-      page.images.owner_suggested.should be nil
+      expect(page.images.owner_suggested).to be nil
     end
   end
 
@@ -114,19 +114,19 @@ describe MetaInspector do
     it "should find the largest image on the page using html sizes" do
       page = MetaInspector.new('http://example.com/largest_image_in_html')
 
-      page.images.largest.should == "http://example.com/largest"
+      expect(page.images.largest).to eq("http://example.com/largest")
     end
 
     it "should find the largest image on the page using actual image sizes" do
       page = MetaInspector.new('http://example.com/largest_image_using_image_size')
 
-      page.images.largest.should == "http://example.com/100x100"
+      expect(page.images.largest).to eq("http://example.com/100x100")
     end
 
     it "should find the largest image without downloading images" do
       page = MetaInspector.new('http://example.com/largest_image_using_image_size', download_images: false)
 
-      page.images.largest.should == "http://example.com/1x1"
+      expect(page.images.largest).to eq("http://example.com/1x1")
     end
   end
 
@@ -134,31 +134,31 @@ describe MetaInspector do
     it "should get favicon link when marked as icon" do
       page = MetaInspector.new('http://pagerankalert.com/')
 
-      page.images.favicon.should == 'http://pagerankalert.com/src/favicon.ico'
+      expect(page.images.favicon).to eq('http://pagerankalert.com/src/favicon.ico')
     end
 
     it "should get favicon link when marked as shortcut" do
       page = MetaInspector.new('http://pagerankalert-shortcut.com/')
 
-      page.images.favicon.should == 'http://pagerankalert-shortcut.com/src/favicon.ico'
+      expect(page.images.favicon).to eq('http://pagerankalert-shortcut.com/src/favicon.ico')
     end
 
     it "should get favicon link when marked as shorcut and icon" do
       page = MetaInspector.new('http://pagerankalert-shortcut-and-icon.com/')
 
-      page.images.favicon.should == 'http://pagerankalert-shortcut-and-icon.com/src/favicon.ico'
+      expect(page.images.favicon).to eq('http://pagerankalert-shortcut-and-icon.com/src/favicon.ico')
     end
 
     it "should get favicon link when there is also a touch icon" do
       page = MetaInspector.new('http://pagerankalert-touch-icon.com/')
 
-      page.images.favicon.should == 'http://pagerankalert-touch-icon.com/src/favicon.ico'
+      expect(page.images.favicon).to eq('http://pagerankalert-touch-icon.com/src/favicon.ico')
     end
 
     it "should get favicon link of nil" do
       page = MetaInspector.new('http://www.theonion.com/articles/apple-claims-new-iphone-only-visible-to-most-loyal,2772/')
 
-      page.images.favicon.should == nil
+      expect(page.images.favicon).to eq(nil)
     end
   end
 end

--- a/spec/meta_inspector/links_spec.rb
+++ b/spec/meta_inspector/links_spec.rb
@@ -5,21 +5,21 @@ describe MetaInspector do
 
   describe '#links' do
     it 'returns the internal links' do
-      page.links.internal.should == [ "http://example.com/",
+      expect(page.links.internal).to eq([ "http://example.com/",
                                         "http://example.com/faqs",
                                         "http://example.com/contact",
-                                        "http://example.com/team.html" ]
+                                        "http://example.com/team.html" ])
     end
 
     it 'returns the external links' do
-      page.links.external.should == [ "https://twitter.com/",
-                                        "https://github.com/" ]
+      expect(page.links.external).to eq([ "https://twitter.com/",
+                                        "https://github.com/" ])
     end
 
     it 'returns the non-HTTP links' do
-      page.links.non_http.should == [ "mailto:hello@example.com",
+      expect(page.links.non_http).to eq([ "mailto:hello@example.com",
                                         "javascript:alert('hi');",
-                                        "ftp://ftp.example.com/" ]
+                                        "ftp://ftp.example.com/" ])
     end
   end
 
@@ -29,81 +29,81 @@ describe MetaInspector do
     end
 
     it "should get correct absolute links for internal pages" do
-      @m.links.internal.should == [ "http://pagerankalert.com/",
+      expect(@m.links.internal).to eq([ "http://pagerankalert.com/",
                                       "http://pagerankalert.com/es?language=es",
                                       "http://pagerankalert.com/users/sign_up",
-                                      "http://pagerankalert.com/users/sign_in" ]
+                                      "http://pagerankalert.com/users/sign_in" ])
     end
 
     it "should get correct absolute links for external pages" do
-      @m.links.external.should == [ "http://pagerankalert.posterous.com/",
+      expect(@m.links.external).to eq([ "http://pagerankalert.posterous.com/",
                                       "http://twitter.com/pagerankalert",
-                                      "http://twitter.com/share" ]
+                                      "http://twitter.com/share" ])
     end
 
     it "should get correct absolute links, correcting relative links from URL not ending with slash" do
       m = MetaInspector.new('http://alazan.com/websolution.asp')
 
-      m.links.internal.should == [ "http://alazan.com/index.asp",
-                                     "http://alazan.com/faqs.asp" ]
+      expect(m.links.internal).to eq([ "http://alazan.com/index.asp",
+                                     "http://alazan.com/faqs.asp" ])
     end
 
     describe "links with international characters" do
       it "should get correct absolute links, encoding the URLs as needed" do
         m = MetaInspector.new('http://international.com')
 
-        m.links.internal.should == [ "http://international.com/espa%C3%B1a.asp",
+        expect(m.links.internal).to eq([ "http://international.com/espa%C3%B1a.asp",
                                        "http://international.com/roman%C3%A9e",
                                        "http://international.com/faqs#cami%C3%B3n",
                                        "http://international.com/search?q=cami%C3%B3n",
                                        "http://international.com/search?q=espa%C3%B1a#top",
-                                       "http://international.com/index.php?q=espa%C3%B1a&url=aHR0zZQ==&cntnt01pageid=21"]
+                                       "http://international.com/index.php?q=espa%C3%B1a&url=aHR0zZQ==&cntnt01pageid=21"])
 
-        m.links.external.should == [ "http://example.com/espa%C3%B1a.asp",
+        expect(m.links.external).to eq([ "http://example.com/espa%C3%B1a.asp",
                                        "http://example.com/roman%C3%A9e",
                                        "http://example.com/faqs#cami%C3%B3n",
                                        "http://example.com/search?q=cami%C3%B3n",
-                                       "http://example.com/search?q=espa%C3%B1a#top"]
+                                       "http://example.com/search?q=espa%C3%B1a#top"])
       end
 
       describe "internal links" do
         it "should get correct internal links, encoding the URLs as needed but respecting # and ?" do
           m = MetaInspector.new('http://international.com')
-          m.links.internal.should == [ "http://international.com/espa%C3%B1a.asp",
+          expect(m.links.internal).to eq([ "http://international.com/espa%C3%B1a.asp",
                                        "http://international.com/roman%C3%A9e",
                                        "http://international.com/faqs#cami%C3%B3n",
                                        "http://international.com/search?q=cami%C3%B3n",
                                        "http://international.com/search?q=espa%C3%B1a#top",
-                                       "http://international.com/index.php?q=espa%C3%B1a&url=aHR0zZQ==&cntnt01pageid=21"]
+                                       "http://international.com/index.php?q=espa%C3%B1a&url=aHR0zZQ==&cntnt01pageid=21"])
         end
 
         it "should not crash when processing malformed hrefs" do
           m = MetaInspector.new('http://example.com/malformed_href')
-          m.links.internal.should == [ "http://example.com/faqs" ]
+          expect(m.links.internal).to eq([ "http://example.com/faqs" ])
         end
       end
 
       describe "external links" do
         it "should get correct external links, encoding the URLs as needed but respecting # and ?" do
           m = MetaInspector.new('http://international.com')
-          m.links.external.should == [ "http://example.com/espa%C3%B1a.asp",
+          expect(m.links.external).to eq([ "http://example.com/espa%C3%B1a.asp",
                                        "http://example.com/roman%C3%A9e",
                                        "http://example.com/faqs#cami%C3%B3n",
                                        "http://example.com/search?q=cami%C3%B3n",
-                                       "http://example.com/search?q=espa%C3%B1a#top"]
+                                       "http://example.com/search?q=espa%C3%B1a#top"])
         end
 
         it "should not crash when processing malformed hrefs" do
           m = MetaInspector.new('http://example.com/malformed_href')
-          m.links.non_http.should == ["skype:joeuser?call", "telnet://telnet.cdrom.com", "javascript:alert('ok');",
-                                        "javascript://", "mailto:email(at)example.com"]
+          expect(m.links.non_http).to eq(["skype:joeuser?call", "telnet://telnet.cdrom.com", "javascript:alert('ok');",
+                                        "javascript://", "mailto:email(at)example.com"])
         end
       end
     end
 
     it "should not crash with links that have weird href values" do
       m = MetaInspector.new('http://example.com/invalid_href')
-      m.links.non_http.should == ["%3Cp%3Eftp://ftp.cdrom.com", "skype:joeuser?call", "telnet://telnet.cdrom.com"]
+      expect(m.links.non_http).to eq(["%3Cp%3Eftp://ftp.cdrom.com", "skype:joeuser?call", "telnet://telnet.cdrom.com"])
     end
   end
 
@@ -114,7 +114,7 @@ describe MetaInspector do
       end
 
       it 'should get the relative links' do
-        @m.links.internal.should == ['http://relative.com/about', 'http://relative.com/sitemap']
+        expect(@m.links.internal).to eq(['http://relative.com/about', 'http://relative.com/sitemap'])
       end
     end
 
@@ -124,7 +124,7 @@ describe MetaInspector do
       end
 
       it 'should get the relative links' do
-        @m.links.internal.should == ['http://relative.com/about', 'http://relative.com/sitemap']
+        expect(@m.links.internal).to eq(['http://relative.com/about', 'http://relative.com/sitemap'])
       end
     end
 
@@ -134,7 +134,7 @@ describe MetaInspector do
       end
 
       it 'should get the relative links' do
-        @m.links.internal.should == ['http://relative.com/company/about', 'http://relative.com/sitemap']
+        expect(@m.links.internal).to eq(['http://relative.com/company/about', 'http://relative.com/sitemap'])
       end
     end
   end
@@ -142,12 +142,12 @@ describe MetaInspector do
   describe 'Relative links with base' do
     it 'should get the relative links from a document' do
       m = MetaInspector.new('http://relativewithbase.com/company/page2')
-      m.links.internal.should == ['http://relativewithbase.com/about', 'http://relativewithbase.com/sitemap']
+      expect(m.links.internal).to eq(['http://relativewithbase.com/about', 'http://relativewithbase.com/sitemap'])
     end
 
     it 'should get the relative links from a directory' do
       m = MetaInspector.new('http://relativewithbase.com/company/page2/')
-      m.links.internal.should == ['http://relativewithbase.com/about', 'http://relativewithbase.com/sitemap']
+      expect(m.links.internal).to eq(['http://relativewithbase.com/about', 'http://relativewithbase.com/sitemap'])
     end
   end
 
@@ -157,13 +157,13 @@ describe MetaInspector do
     end
 
     it "should get the links" do
-      @m.links.non_http.sort.should == [
+      expect(@m.links.non_http.sort).to eq([
                                 "ftp://ftp.cdrom.com/",
                                 "javascript:alert('hey');",
                                 "mailto:user@example.com",
                                 "skype:joeuser?call",
                                 "telnet://telnet.cdrom.com"
-                              ]
+                              ])
     end
   end
 
@@ -174,30 +174,30 @@ describe MetaInspector do
     end
 
     it "should convert protocol-relative links to http" do
-      @m_http.links.internal.should include('http://protocol-relative.com/contact')
-      @m_http.links.external.should include('http://yahoo.com/')
+      expect(@m_http.links.internal).to include('http://protocol-relative.com/contact')
+      expect(@m_http.links.external).to include('http://yahoo.com/')
     end
 
     it "should convert protocol-relative links to https" do
-      @m_https.links.internal.should include('https://protocol-relative.com/contact')
-      @m_https.links.external.should include('https://yahoo.com/')
+      expect(@m_https.links.internal).to include('https://protocol-relative.com/contact')
+      expect(@m_https.links.external).to include('https://yahoo.com/')
     end
   end
 
   describe "Feed" do
     it "should get rss feed" do
       @m = MetaInspector.new('http://www.iteh.at')
-      @m.feed.should == 'http://www.iteh.at/de/rss/'
+      expect(@m.feed).to eq('http://www.iteh.at/de/rss/')
     end
 
     it "should get atom feed" do
       @m = MetaInspector.new('http://www.tea-tron.com/jbravo/blog/')
-      @m.feed.should == 'http://www.tea-tron.com/jbravo/blog/feed/'
+      expect(@m.feed).to eq('http://www.tea-tron.com/jbravo/blog/feed/')
     end
 
     it "should return nil if no feed found" do
       @m = MetaInspector.new('http://www.alazan.com')
-      @m.feed.should == nil
+      expect(@m.feed).to eq(nil)
     end
   end
 end

--- a/spec/meta_inspector/meta_inspector_spec.rb
+++ b/spec/meta_inspector/meta_inspector_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe MetaInspector do
   it "returns a Document" do
-    MetaInspector.new('http://example.com').class.should == MetaInspector::Document
+    expect(MetaInspector.new('http://example.com').class).to eq(MetaInspector::Document)
   end
 end

--- a/spec/meta_inspector/meta_tags_spec.rb
+++ b/spec/meta_inspector/meta_tags_spec.rb
@@ -6,7 +6,7 @@ describe MetaInspector do
     let(:page) { MetaInspector.new('http://example.com/meta-tags') }
 
     it "#meta_tags" do
-      page.meta_tags.should == {
+      expect(page.meta_tags).to eq({
                                   'name' => {
                                               'keywords'       => ['one, two, three'],
                                               'description'    => ['the description'],
@@ -33,11 +33,11 @@ describe MetaInspector do
                                                 },
 
                                   'charset' => ['UTF-8']
-                                }
+                                })
     end
 
     it "#meta_tag" do
-      page.meta_tag.should == {
+      expect(page.meta_tag).to eq({
                                   'name' => {
                                               'keywords'       => 'one, two, three',
                                               'description'    => 'the description',
@@ -62,11 +62,11 @@ describe MetaInspector do
                                                 },
 
                                   'charset' => 'UTF-8'
-                                }
+                                })
     end
 
     it "#meta" do
-      page.meta.should == {
+      expect(page.meta).to eq({
                             'keywords'            => 'one, two, three',
                             'description'         => 'the description',
                             'author'              => 'Joe Sample',
@@ -82,7 +82,7 @@ describe MetaInspector do
                             'og:image:width'      => '300',
                             'og:image:height'     => '300',
                             'charset'             => 'UTF-8'
-                          }
+                          })
     end
   end
 
@@ -90,19 +90,19 @@ describe MetaInspector do
     it "should get the charset from <meta charset />" do
       page = MetaInspector.new('http://charset001.com')
 
-      page.charset.should == "utf-8"
+      expect(page.charset).to eq("utf-8")
     end
 
     it "should get the charset from meta content type" do
       page = MetaInspector.new('http://charset002.com')
 
-      page.charset.should == "windows-1252"
+      expect(page.charset).to eq("windows-1252")
     end
 
     it "should get nil if no declared charset is found" do
       page = MetaInspector.new('http://charset000.com')
 
-      page.charset.should == nil
+      expect(page.charset).to eq(nil)
     end
   end
 end

--- a/spec/meta_inspector/redirections_spec.rb
+++ b/spec/meta_inspector/redirections_spec.rb
@@ -8,17 +8,17 @@ describe MetaInspector do
       it "disallows redirections" do
         page = MetaInspector.new("http://facebook.com", :allow_redirections => false)
 
-        page.url.should == "http://facebook.com/"
+        expect(page.url).to eq("http://facebook.com/")
       end
     end
 
     context "when redirections are on (default)" do
       it "allows follows redirections" do
-        logger.should_not receive(:<<)
+        expect(logger).not_to receive(:<<)
 
         page = MetaInspector.new("http://facebook.com", exception_log: logger)
 
-        page.url.should == "https://www.facebook.com/"
+        expect(page.url).to eq("https://www.facebook.com/")
       end
     end
 
@@ -37,11 +37,11 @@ describe MetaInspector do
         stub_request(:get, "http://blogs.clarionledger.com/dechols/2014/03/24/digital-medicine/?nclick_check=1")
           .with(:headers => {"Cookie" => "EMETA_COOKIE_CHECK=1"})
 
-        logger.should_not receive(:<<)
+        expect(logger).not_to receive(:<<)
 
         page = MetaInspector.new("http://blogs.clarionledger.com/dechols/2014/03/24/digital-medicine/", exception_log: logger)
 
-        page.url.should == "http://blogs.clarionledger.com/dechols/2014/03/24/digital-medicine/?nclick_check=1"
+        expect(page.url).to eq("http://blogs.clarionledger.com/dechols/2014/03/24/digital-medicine/?nclick_check=1")
       end
     end
   end

--- a/spec/meta_inspector/texts_spec.rb
+++ b/spec/meta_inspector/texts_spec.rb
@@ -3,38 +3,38 @@ require 'spec_helper'
 describe MetaInspector do
   it "should get the title from the head section" do
     page = MetaInspector.new('http://example.com')
-    page.title.should == 'An example page'
+    expect(page.title).to eq('An example page')
   end
 
   describe '#best_title' do
     it "should find 'head title' when that's the only thing" do
       page = MetaInspector.new('http://example.com/title_in_head')
-      page.best_title.should == 'This title came from the head'
+      expect(page.best_title).to eq('This title came from the head')
     end
 
     it "should find 'body title' when that's the only thing" do
       page = MetaInspector.new('http://example.com/title_in_body')
-      page.best_title.should == 'This title came from the body, not the head'
+      expect(page.best_title).to eq('This title came from the body, not the head')
     end
 
     it "should find 'og:title' when that's the only thing" do
       page = MetaInspector.new('http://example.com/meta-tags')
-      page.best_title.should == 'An OG title'
+      expect(page.best_title).to eq('An OG title')
     end
 
     it "should find the first <h1> when that's the only thing" do
       page = MetaInspector.new('http://example.com/title_in_h1')
-      page.best_title.should == 'This title came from the first h1'
+      expect(page.best_title).to eq('This title came from the first h1')
     end
 
     it "should choose the longest candidate from the available options" do
       page = MetaInspector.new('http://example.com/title_best_choice')
-      page.best_title.should == 'This title came from the first h1 and should be the longest of them all, so should be chosen'
+      expect(page.best_title).to eq('This title came from the first h1 and should be the longest of them all, so should be chosen')
     end
 
     it "should strip leading and trailing whitespace and all line breaks" do
       page = MetaInspector.new('http://example.com/title_in_head_with_whitespace')
-      page.best_title.should == 'This title came from the head and has leading and trailing whitespace'
+      expect(page.best_title).to eq('This title came from the head and has leading and trailing whitespace')
     end
 
   end
@@ -43,12 +43,12 @@ describe MetaInspector do
     it "should find description from meta description" do
       page = MetaInspector.new('http://www.youtube.com/watch?v=iaGSSrp49uc')
 
-      page.description.should == "This is Youtube"
+      expect(page.description).to eq("This is Youtube")
     end
 
     it "should find a secondary description if no meta description" do
       page = MetaInspector.new('http://theonion-no-description.com')
-      page.description.should == "SAN FRANCISCO—In a move expected to revolutionize the mobile device industry, Apple launched its fastest and most powerful iPhone to date Tuesday, an innovative new model that can only be seen by the company's hippest and most dedicated customers. This is secondary text picked up because of a missing meta description."
+      expect(page.description).to eq("SAN FRANCISCO—In a move expected to revolutionize the mobile device industry, Apple launched its fastest and most powerful iPhone to date Tuesday, an innovative new model that can only be seen by the company's hippest and most dedicated customers. This is secondary text picked up because of a missing meta description.")
     end
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -5,10 +5,10 @@ describe MetaInspector::Parser do
   let(:parser) { MetaInspector::Parser.new(doc) }
 
   it "should have a Nokogiri::HTML::Document as parsed" do
-    parser.parsed.class.should == Nokogiri::HTML::Document
+    expect(parser.parsed.class).to eq(Nokogiri::HTML::Document)
   end
 
   it "should return the document as a string" do
-    parser.to_s.class.should == String
+    expect(parser.to_s.class).to eq(String)
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -6,24 +6,24 @@ describe MetaInspector::Request do
     it "should return the content of the page" do
       page_request = MetaInspector::Request.new(url('http://pagerankalert.com'))
 
-      page_request.read[0..14].should == "<!DOCTYPE html>"
+      expect(page_request.read[0..14]).to eq("<!DOCTYPE html>")
     end
   end
 
   describe "response" do
     it "contains the response status" do
       page_request = MetaInspector::Request.new(url('http://example.com'))
-      page_request.response.status.should == 200
+      expect(page_request.response.status).to eq(200)
     end
 
     it "contains the response headers" do
       page_request = MetaInspector::Request.new(url('http://example.com'))
-      page_request.response.headers
-        .should == {"server"=>"nginx/0.7.67", "date"=>"Fri, 18 Nov 2011 21:46:46 GMT",
+      expect(page_request.response.headers)
+        .to eq({"server"=>"nginx/0.7.67", "date"=>"Fri, 18 Nov 2011 21:46:46 GMT",
                     "content-type"=>"text/html", "connection"=>"keep-alive",
                     "last-modified"=>"Mon, 14 Nov 2011 16:53:18 GMT",
                     "content-length"=>"4987", "x-varnish"=>"2000423390",
-                    "age"=>"0", "via"=>"1.1 varnish"}
+                    "age"=>"0", "via"=>"1.1 varnish"})
     end
   end
 
@@ -31,13 +31,13 @@ describe MetaInspector::Request do
     it "should return the correct content type of the url for html pages" do
       page_request = MetaInspector::Request.new(url('http://pagerankalert.com'))
 
-      page_request.content_type.should == "text/html"
+      expect(page_request.content_type).to eq("text/html")
     end
 
     it "should return the correct content type of the url for non html pages" do
       image_request = MetaInspector::Request.new(url('http://pagerankalert.com/image.png'))
 
-      image_request.content_type.should == "image/png"
+      expect(image_request.content_type).to eq("image/png")
     end
   end
 
@@ -53,8 +53,8 @@ describe MetaInspector::Request do
     end
 
     it "should handle socket errors" do
-      TCPSocket.stub(:open).and_raise(SocketError)
-      logger.should receive(:<<).with(an_instance_of(Faraday::Error::ConnectionFailed))
+      allow(TCPSocket).to receive(:open).and_raise(SocketError)
+      expect(logger).to receive(:<<).with(an_instance_of(Faraday::Error::ConnectionFailed))
 
       MetaInspector::Request.new(url('http://caca232dsdsaer3sdsd-asd343.org'), exception_log: logger)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,6 @@ end
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
-  config.treat_symbols_as_metadata_keys_with_true_values = true #rspec 3 default
 end
 
 #######################

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -2,38 +2,38 @@ require 'spec_helper'
 
 describe MetaInspector::URL do
   it "should normalize URLs" do
-    MetaInspector::URL.new('http://example.com').url.should == 'http://example.com/'
+    expect(MetaInspector::URL.new('http://example.com').url).to eq('http://example.com/')
   end
 
   it 'should accept an URL with a scheme' do
-    MetaInspector::URL.new('http://example.com/').url.should == 'http://example.com/'
+    expect(MetaInspector::URL.new('http://example.com/').url).to eq('http://example.com/')
   end
 
   it "should use http:// as a default scheme" do
-    MetaInspector::URL.new('example.com').url.should == 'http://example.com/'
+    expect(MetaInspector::URL.new('example.com').url).to eq('http://example.com/')
   end
 
   it "should accept an URL with international characters" do
-    MetaInspector::URL.new('http://international.com/olé').url.should == 'http://international.com/ol%C3%A9'
+    expect(MetaInspector::URL.new('http://international.com/olé').url).to eq('http://international.com/ol%C3%A9')
   end
 
   it "should return the scheme" do
-    MetaInspector::URL.new('http://example.com').scheme.should   == 'http'
-    MetaInspector::URL.new('https://example.com').scheme.should  == 'https'
-    MetaInspector::URL.new('example.com').scheme.should          == 'http'
+    expect(MetaInspector::URL.new('http://example.com').scheme).to   eq('http')
+    expect(MetaInspector::URL.new('https://example.com').scheme).to  eq('https')
+    expect(MetaInspector::URL.new('example.com').scheme).to          eq('http')
   end
 
   it "should return the host" do
-    MetaInspector::URL.new('http://example.com').host.should   == 'example.com'
-    MetaInspector::URL.new('https://example.com').host.should  == 'example.com'
-    MetaInspector::URL.new('example.com').host.should          == 'example.com'
+    expect(MetaInspector::URL.new('http://example.com').host).to   eq('example.com')
+    expect(MetaInspector::URL.new('https://example.com').host).to  eq('example.com')
+    expect(MetaInspector::URL.new('example.com').host).to          eq('example.com')
   end
 
   it "should return the root url" do
-    MetaInspector::URL.new('http://example.com').root_url.should        == 'http://example.com/'
-    MetaInspector::URL.new('https://example.com').root_url.should       == 'https://example.com/'
-    MetaInspector::URL.new('example.com').root_url.should               == 'http://example.com/'
-    MetaInspector::URL.new('http://example.com/faqs').root_url.should   == 'http://example.com/'
+    expect(MetaInspector::URL.new('http://example.com').root_url).to        eq('http://example.com/')
+    expect(MetaInspector::URL.new('https://example.com').root_url).to       eq('https://example.com/')
+    expect(MetaInspector::URL.new('example.com').root_url).to               eq('http://example.com/')
+    expect(MetaInspector::URL.new('http://example.com/faqs').root_url).to   eq('http://example.com/')
   end
 
   describe "url=" do
@@ -41,14 +41,14 @@ describe MetaInspector::URL do
       url = MetaInspector::URL.new('http://first.com/')
 
       url.url         = 'http://second.com/'
-      url.url.should == 'http://second.com/'
+      expect(url.url).to eq('http://second.com/')
     end
 
     it "should add the missing scheme and normalize" do
       url = MetaInspector::URL.new('http://first.com/')
 
       url.url         = 'second.com'
-      url.url.should == 'http://second.com/'
+      expect(url.url).to eq('http://second.com/')
     end
   end
 end


### PR DESCRIPTION
Hi Jamie, 

I recently used metainspector in a recent project of mine. Thanks for the initiative. 

I wanted to contribute somehow and I noticed the tests showed some deprecation warnings. So I upgraded RSpec to 3.0 and updated the tests with the new syntax. 

I was not sure if this RSpec upgrade required an update in the metainspector version.rb file as no features per se were added. Let me know if I am mistaken. I can add the semantic versioning per your request.

Thanks again.