### PR TITLE
Fix images.best for malformed img tags (no src attribute)

### DIFF
--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -35,7 +35,7 @@ module MetaInspector
       # filtered for images that are more square than 10:1 or 1:10
       def largest()
         @larget_image ||= begin
-          img_nodes = parsed.search('//img')
+          img_nodes = parsed.search('//img').select{ |img_node| img_node['src'] }
           sizes = img_nodes.map { |img_node| [URL.absolutify(img_node['src'], base_url), img_node['width'], img_node['height']] }
           sizes.uniq! { |url, width, height| url }
           if @download_images

--- a/spec/fixtures/malformed_image_in_html.response
+++ b/spec/fixtures/malformed_image_in_html.response
@@ -1,0 +1,23 @@
+HTTP/1.1 200 OK
+Server: nginx/0.7.67
+Date: Fri, 18 Nov 2011 21:46:46 GMT
+Content-Type: text/html
+Connection: keep-alive
+Last-Modified: Mon, 14 Nov 2011 16:53:18 GMT
+Content-Length: 4987
+X-Varnish: 2000423390
+Age: 0
+Via: 1.1 varnish
+
+<html>
+  <head>
+    <title>An example page</title>
+  </head>
+  <body>
+    <img src="/too_narrow" width="10"  height="100" />
+    <img src="/smaller"    width="10"  height="10"  />
+    <img src="/largest"    width="100" height="100" />
+    <img                   width="100" height="10"  />
+    <img src="/smallest"   width="1"   height="1"   />
+  </body>
+</html>

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -88,6 +88,13 @@ describe MetaInspector do
 
       expect(page.images.best).to eq("http://example.com/100x100")
     end
+
+    it "should find image when some img tag has no src attribute" do
+      page = MetaInspector.new('http://example.com/malformed_image_in_html')
+
+      expect(page.images.best).to eq("http://example.com/largest")
+    end
+
   end
 
   describe "images.owner_suggested" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ FakeWeb.register_uri(:get, "http://example.com/no-content-type", :response => fi
 # Used to test largest image in page logic
 FakeWeb.register_uri(:get, "http://example.com/largest_image_in_html", :response => fixture_file("largest_image_in_html.response"))
 FakeWeb.register_uri(:get, "http://example.com/largest_image_using_image_size", :response => fixture_file("largest_image_using_image_size.response"))
+FakeWeb.register_uri(:get, "http://example.com/malformed_image_in_html", :response => fixture_file("malformed_image_in_html.response"))
 FakeWeb.register_uri(:get, "http://example.com/10x10", :response => fixture_file("10x10.jpg.response"))
 FakeWeb.register_uri(:get, "http://example.com/100x100", :response => fixture_file("100x100.jpg.response"))
 


### PR DESCRIPTION
Hi! I found that `page.images.best` throws an exception if some of the image tags has no `src` attribute (here is an example: http://diy3dprinting.blogspot.com.ar/2015/01/how-to-use-friction-welding-to-repair.html). I created a test for that and also patched the `largest` method to avoid that.

Hope it helps. Thanks for this great gem.