### PR TITLE
Supported for language Document language method. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MetaInspector is a gem for web scraping purposes.
 
-You give it an URL, and it lets you easily get its title, links, images, charset, description, keywords, meta tags...
+You give it an URL, and it lets you easily get its title, links, images, charset, language, description, keywords, meta tags...
 
 ## See it in action!
 
@@ -123,6 +123,7 @@ page.images              # enumerable collection, with every img found on the pa
 page.images.best         # Most relevant image, if defined with the og:image or twitter:image metatags. Fallback to the first page.images array element
 page.images.favicon      # absolute URL to the favicon
 page.feed                # Get rss or atom links in meta data fields as array
+page.language            # Get language of site en-US / de
 page.charset             # UTF-8
 page.content_type        # content-type returned by the server when the url was requested
 ```
@@ -133,7 +134,7 @@ When it comes to meta tags, you have several options:
 
 ```ruby
 page.meta_tags  # Gives you all the meta tags by type:
-                # (meta name, meta http-equiv, meta property and meta charset)
+                # (meta name, meta http-equiv, meta property, meta charset and language)
                 # As meta tags can be repeated (in the case of 'og:image', for example),
                 # the values returned will be arrays
                 #
@@ -164,6 +165,8 @@ page.meta_tags  # Gives you all the meta tags by type:
                                     'og:image:width'  => ['300'],
                                     'og:image:height' => ['300', '1000']
                                    },
+
+                    'language' => ['en-US'],
 
                     'charset' => ['UTF-8']
                   }
@@ -227,6 +230,7 @@ page.meta   # Returns:
             #   'og:image'            => 'http://example.com/rock.jpg',
             #   'og:image:width'      => '300',
             #   'og:image:height'     => '300',
+            #   'language'            => 'en-US',
             #   'charset'             => 'UTF-8'
             # }
 ```

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -51,7 +51,7 @@ module MetaInspector
     delegate [:parsed, :title, :best_title,
               :description, :links,
               :images, :feed, :charset, :meta_tags,
-              :meta_tag, :meta, :favicon]             => :@parser
+              :meta_tag, :meta, :favicon, :language]             => :@parser
 
     # Returns all document data as a nested Hash
     def to_hash
@@ -66,6 +66,7 @@ module MetaInspector
         'links'         => links.to_hash,
         'images'        => images.to_a,
         'charset'       => charset,
+        'language'      => language,
         'feed'          => feed,
         'content_type'  => content_type,
         'meta_tags'     => meta_tags,

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -21,11 +21,11 @@ module MetaInspector
     end
 
     extend Forwardable
-    delegate [:url, :scheme, :host]                   => :@document
-    delegate [:meta_tags, :meta_tag, :meta, :charset] => :@meta_tag_parser
-    delegate [:links, :feed, :base_url]               => :@links_parser
-    delegate :images                                  => :@images_parser
-    delegate [:title, :best_title, :description]      => :@texts_parser
+    delegate [:url, :scheme, :host]                              => :@document
+    delegate [:meta_tags, :meta_tag, :meta, :charset, :language] => :@meta_tag_parser
+    delegate [:links, :feed, :base_url]                          => :@links_parser
+    delegate :images                                             => :@images_parser
+    delegate [:title, :best_title, :description]                 => :@texts_parser
 
     # Returns the whole parsed document
     def parsed

--- a/lib/meta_inspector/parsers/meta_tags.rb
+++ b/lib/meta_inspector/parsers/meta_tags.rb
@@ -8,6 +8,7 @@ module MetaInspector
           'name'        => meta_tags_by('name'),
           'http-equiv'  => meta_tags_by('http-equiv'),
           'property'    => meta_tags_by('property'),
+          'language'    => [html_tags_by('lang')],
           'charset'     => [charset_from_meta_charset]
         }
       end
@@ -20,6 +21,7 @@ module MetaInspector
         meta_tag['name']
           .merge(meta_tag['http-equiv'])
           .merge(meta_tag['property'])
+          .merge('language' => meta_tag['language'])
           .merge('charset' => meta_tag['charset'])
       end
 
@@ -28,6 +30,10 @@ module MetaInspector
       # <meta http-equiv="Content-Type" content="text/html; charset=windows-1252" />
       def charset
         @charset ||= (charset_from_meta_charset || charset_from_meta_content_type)
+      end
+
+      def language
+        @language ||= html_tags_by('lang')
       end
 
       private
@@ -53,6 +59,14 @@ module MetaInspector
           end
         end
         hash
+      end
+
+      def html_tags_by(attribute)
+        content = nil
+        parsed.css("html[@#{attribute}]").map do |tag|
+          content = tag.attributes[attribute].value rescue nil
+        end
+        content
       end
 
       def convert_each_array_to_first_element_on(hash)

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -40,6 +40,7 @@ describe MetaInspector::Document do
                                                   },
                             "images"          => ["http://pagerankalert.com/images/pagerank_alert.png?1305794559"],
                             "charset"         => "utf-8",
+                            "language"        => "en-US",
                             "feed"            => "http://feeds.feedburner.com/PageRankAlert",
                             "content_type"    => "text/html",
                             "meta_tags"       => {
@@ -51,6 +52,7 @@ describe MetaInspector::Document do
                                                              },
                                                    "http-equiv" => {},
                                                    "property"   => {},
+                                                   "language"   => ["en-US"],
                                                    "charset"    => ["utf-8"]
                                                  },
                             "response"        => {

--- a/spec/fixtures/charset_001.response
+++ b/spec/fixtures/charset_001.response
@@ -12,7 +12,7 @@ Cache-control: private
 
 
 
-<html>
+<html lang="en-US">
 <head>
   <meta charset="utf-8" />
   <title>A web</title>

--- a/spec/fixtures/example.response
+++ b/spec/fixtures/example.response
@@ -9,7 +9,7 @@ X-Varnish: 2000423390
 Age: 0
 Via: 1.1 varnish
 
-<html>
+<html lang="en-US">
   <head>
     <title>An example page</title>
   </head>

--- a/spec/fixtures/meta_tags.response
+++ b/spec/fixtures/meta_tags.response
@@ -13,7 +13,7 @@ Content-Length: 40571
 Connection: keep-alive
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US">
   <head>
     <!-- meta name examples -->
 

--- a/spec/fixtures/pagerankalert.com.response
+++ b/spec/fixtures/pagerankalert.com.response
@@ -14,7 +14,7 @@ Age: 0
 Via: 1.1 varnish
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
 <head>
   <meta charset=utf-8>
   <link rel="alternate" type="application/rss+xml" title="PageRankAlert.com blog" href="http://feeds.feedburner.com/PageRankAlert" />

--- a/spec/meta_inspector/meta_tags_spec.rb
+++ b/spec/meta_inspector/meta_tags_spec.rb
@@ -32,6 +32,8 @@ describe MetaInspector do
                                                   'og:image:height' => ['300', '1000']
                                                 },
 
+                                  'language' => ['en-US'],
+
                                   'charset' => ['UTF-8']
                                 })
     end
@@ -61,6 +63,8 @@ describe MetaInspector do
                                                   'og:image:height' => '300'
                                                 },
 
+                                  'language' => 'en-US',
+
                                   'charset' => 'UTF-8'
                                 })
     end
@@ -81,6 +85,7 @@ describe MetaInspector do
                             'og:image'            => 'http://example.com/rock.jpg',
                             'og:image:width'      => '300',
                             'og:image:height'     => '300',
+                            'language'            => 'en-US',
                             'charset'             => 'UTF-8'
                           })
     end
@@ -103,6 +108,20 @@ describe MetaInspector do
       page = MetaInspector.new('http://charset000.com')
 
       expect(page.charset).to eq(nil)
+    end
+  end
+
+  describe 'language detection' do
+    it "should get the language from <html lang />" do
+      page = MetaInspector.new('http://charset001.com')
+
+      expect(page.language).to eq("en-US")
+    end
+
+    it "should get nil if no declared language is found" do
+      page = MetaInspector.new('http://charset000.com')
+
+      expect(page.language).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
Added support per issue #121 - Document language method.

Added method to return language and also return in meta-tag.
Modified specs, fixtures and read.me for these changes.