### PR TITLE
Absulutify owner_suggested image

### DIFF
--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -28,7 +28,8 @@ module MetaInspector
       # See doc at http://developers.facebook.com/docs/opengraph/
       # If none found, tries with Twitter image
       def owner_suggested
-        meta['og:image'] || meta['twitter:image']
+        suggested_img = meta['og:image'] || meta['twitter:image']
+        URL.absolutify(suggested_img, base_url) if suggested_img
       end
 
       # Returns the largest image from the image collection,

--- a/spec/fixtures/relative_og_image.response
+++ b/spec/fixtures/relative_og_image.response
@@ -1,0 +1,44 @@
+HTTP/1.1 200 OK
+Server: nginx/0.7.67
+Date: Fri, 18 Nov 2011 21:46:46 GMT
+Content-Type: text/html
+Connection: keep-alive
+Last-Modified: Mon, 14 Nov 2011 16:53:18 GMT
+Content-Length: 4987
+X-Varnish: 2000423390
+Age: 0
+Via: 1.1 varnish
+
+<html>
+  <head>
+    <title>An example page</title>
+    <meta property="og:image" content="/wp-content/uploads/2015/03/50316106.jpg" />
+  </head>
+  <body>
+    <!-- An SVG tag can have a title tag, should not interfere with the head title tag -->
+    <!-- https://github.com/jaimeiniesta/metainspector/issues/83 -->
+    <svg width="500" height="300" xmlns="http://www.w3.org/2000/svg">
+      <g>
+        <title>SVG Title Demo example</title>
+        <rect x="10" y="10" width="200" height="50" style="fill:none; stroke:blue; stroke-width:1px"/>
+      </g>
+    </svg>
+
+    <!-- Internal relative links -->
+    <a href="/">Root</a>
+    <a href="/faqs">FAQs</a>
+    <a href="contact">Contact</a>
+
+    <!-- Internal absolute links -->
+    <a href="http://example.com/team.html">Team</a>
+
+    <!-- External links -->
+    <a href="https://twitter.com">Twitter</a>
+    <a href="https://github.com">Github</a>
+
+    <!-- Non-HTTP links -->
+    <a href="mailto:hello@example.com">email</a>
+    <a href="javascript:alert('hi');">hello</a>
+    <a href="ftp://ftp.example.com">FTP</a>
+  </body>
+</html>

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -110,6 +110,12 @@ describe MetaInspector do
       expect(page.images.owner_suggested).to eq("http://i2.ytimg.com/vi/iaGSSrp49uc/mqdefault.jpg")
     end
 
+    it "should absolutify image" do
+      page = MetaInspector.new('http://www.24-horas.mx/mexico-firma-acuerdo-bilateral-automotriz-con-argentina/')
+
+      expect(page.images.owner_suggested).to eq("http://www.24-horas.mx/wp-content/uploads/2015/03/50316106.jpg")
+    end
+
     it "should return nil when og:image and twitter:image metatags are missing" do
       page = MetaInspector.new('http://example.com/largest_image_using_image_size')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ FakeWeb.register_uri(:get, "http://example.com/largest_image_using_image_size", 
 FakeWeb.register_uri(:get, "http://example.com/malformed_image_in_html", :response => fixture_file("malformed_image_in_html.response"))
 FakeWeb.register_uri(:get, "http://example.com/10x10", :response => fixture_file("10x10.jpg.response"))
 FakeWeb.register_uri(:get, "http://example.com/100x100", :response => fixture_file("100x100.jpg.response"))
+FakeWeb.register_uri(:get, "http://www.24-horas.mx/mexico-firma-acuerdo-bilateral-automotriz-con-argentina/", :response => fixture_file("relative_og_image.response"))
 
 # Used to test best_title logic
 FakeWeb.register_uri(:get, "http://example.com/title_in_head", :response => fixture_file("title_in_head.response"))


### PR DESCRIPTION
Hi Jaime! I found some sites that use a relative url for the og:image meta header and then `page.images.owner_suggested` returns a relative url, so I created a test for that case an a fix for the problem. If you find it useful, please merge it into your repo.

Thanks so much for great work!