### PR TITLE
Add page.images.with_size that returns a sorted by area array of [img_url, width, height]

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ You can try MetaInspector live at this little demo: [https://metainspectordemo.h
     * `url.untracked_url` will return the url with known tracking parameters removed
     * `url.untrack!` will remove the tracking parameters from the url
 
+* The images API has been extended:
+    * `page.images.with_size` returns a sorted array (by descending area) of [image_url, width, height]
+
 ## Changes in 4.4
 
 The default headers now include `'Accept-Encoding' => 'identity'` to minimize trouble with servers that respond with malformed compressed responses, [as explained here](https://github.com/lostisland/faraday/issues/337).

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -32,28 +32,37 @@ module MetaInspector
         URL.absolutify(suggested_img, base_url) if suggested_img
       end
 
-      # Returns the largest image from the image collection,
-      # filtered for images that are more square than 10:1 or 1:10
-      def largest()
-        @larget_image ||= begin
+      # Returns an array of [img_url, width, height] sorted by image area (width * height)
+      def with_size
+        @with_size ||= begin
           img_nodes = parsed.search('//img').select{ |img_node| img_node['src'] }
-          sizes = img_nodes.map { |img_node| [URL.absolutify(img_node['src'], base_url), img_node['width'], img_node['height']] }
-          sizes.uniq! { |url, width, height| url }
+          imgs_with_size = img_nodes.map { |img_node| [URL.absolutify(img_node['src'], base_url), img_node['width'], img_node['height']] }
+          imgs_with_size.uniq! { |url, width, height| url }
           if @download_images
-            sizes.map! do |url, width, height|
+            imgs_with_size.map! do |url, width, height|
               width, height = FastImage.size(url) if width.nil? || height.nil?
-              [url, width, height]
+              [url, width.to_i, height.to_i]
             end
           else
-            sizes.map! do |url, width, height|
+            imgs_with_size.map! do |url, width, height|
               width, height = [0, 0] if width.nil? || height.nil?
-              [url, width, height]
+              [url, width.to_i, height.to_i]
             end
           end
-          sizes.map! { |url, width, height| [url, width.to_i * height.to_i, width.to_f / height.to_f] }
-          sizes.keep_if { |url, area, ratio| ratio > 0.1 && ratio < 10 }
-          sizes.sort_by! { |url, area, ratio| -area }
-          url, area, ratio = sizes.first
+          imgs_with_size.sort_by { |url, width, height| -(width.to_i * height.to_i) }
+        end
+      end
+
+      # Returns the largest image from the image collection,
+      # filtered for images that are more square than 10:1 or 1:10
+      def largest
+        @largest_image ||= begin
+          imgs_with_size = with_size.dup
+          imgs_with_size.keep_if do |url, width, height|
+            ratio = width.to_f / height.to_f
+            ratio > 0.1 && ratio < 10
+          end
+          url, width, height = imgs_with_size.first
           url
         end
       end

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -123,6 +123,44 @@ describe MetaInspector do
     end
   end
 
+  describe "images.with_size" do
+    it "should return sorted by area array of [img_url, width, height] using html sizes" do
+      page = MetaInspector.new('http://example.com/largest_image_in_html')
+
+      expect(page.images.with_size).to eq([
+        ["http://example.com/largest", 100, 100],
+        ["http://example.com/too_narrow", 10, 100],
+        ["http://example.com/too_wide", 100, 10],
+        ["http://example.com/smaller", 10, 10],
+        ["http://example.com/smallest", 1, 1]
+      ])
+    end
+
+    it "should return sorted by area array of [img_url, width, height] using actual image sizes" do
+      page = MetaInspector.new('http://example.com/largest_image_using_image_size')
+
+      expect(page.images.with_size).to eq([
+        ["http://example.com/100x100", 100, 100],
+        ["http://example.com/10x100", 10, 100],
+        ["http://example.com/100x10", 100, 10],
+        ["http://example.com/10x10", 10, 10],
+        ["http://example.com/1x1", 1, 1]
+      ])
+    end
+
+    it "should return sorted by area array of [img_url, width, height] without downloading images" do
+      page = MetaInspector.new('http://example.com/largest_image_using_image_size', download_images: false)
+
+      expect(page.images.with_size).to eq([
+        ["http://example.com/10x100", 10, 100],
+        ["http://example.com/100x10", 100, 10],
+        ["http://example.com/1x1", 1, 1],
+        ["http://example.com/10x10", 0, 0],
+        ["http://example.com/100x100", 0, 0]
+      ])
+    end
+  end
+
   describe "images.largest" do
     it "should find the largest image on the page using html sizes" do
       page = MetaInspector.new('http://example.com/largest_image_in_html')


### PR DESCRIPTION
Hi @jaimeiniesta! I saw this comment https://github.com/jaimeiniesta/metainspector/issues/90#issuecomment-70811310 and thought that it'd be very useful to have this feature.

With this PR it is possible to call `page.images.with_size` and obtain a sorted array by size like this:

``` ruby
=> [  ["http://example.com/largest", 100, 100],
        ["http://example.com/too_narrow", 10, 100],
        ["http://example.com/too_wide", 100, 10],
        ["http://example.com/smaller", 10, 10],
        ["http://example.com/smallest", 1, 1]
   ]
```
I dryed `#largest` to take advantage of the logic that I moved to `#with_size`. I also added the corresponding test for `#with_size` and make sure that all previous test passed ok.

Hope it helps!

Juan.