### PR TITLE
Add tests to verify that image urls are already unrelativize

### DIFF
--- a/lib/meta_inspector/parsers/head_links.rb
+++ b/lib/meta_inspector/parsers/head_links.rb
@@ -5,7 +5,14 @@ module MetaInspector
 
       def head_links
         @head_links ||= parsed.css('head link').map do |tag|
-          Hash[tag.attributes.keys.map { |key| [key.to_sym, tag.attributes[key].value] }]
+          Hash[
+            tag.attributes.keys.map do |key|
+              keysym = key.to_sym
+              val = tag.attributes[key].value
+              val = URL.absolutify(val, base_url) if keysym == :href
+              [keysym, val]
+            end
+          ]
         end
       end
 

--- a/spec/fixtures/head_links.response
+++ b/spec/fixtures/head_links.response
@@ -17,6 +17,7 @@ Via: 1.1 varnish
         href="http://example.com/canonical-from-head"
     />
     <link rel="stylesheet" href="/stylesheets/screen.css">
+    <link rel="stylesheet" href="//example2.com/stylesheets/screen.css">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="shorturl" href="http://gu.com/p/32v5a" />
     <link

--- a/spec/fixtures/protocol_relative.response
+++ b/spec/fixtures/protocol_relative.response
@@ -12,6 +12,8 @@ Accept-Ranges: bytes
 <head>
   <meta charset="utf-8" />
   <title>Protocol-relative URLs</title>
+  <meta property="og:image" content="//static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/8/8/1312810126887/gu_192x115.jpg"/>
+  <link rel="shortcut icon" href="//static-secure.guim.co.uk/sys-images/favicon.ico" type="image/x-icon" />
 </head>
 <body>
   <p>Internal links</p>
@@ -22,5 +24,8 @@ Accept-Ranges: bytes
   <p>External links</p>
   <a href="http://google.com">External: normal link</a>
   <a href="//yahoo.com">External: protocol-relative link</a>
+
+  <p>Images</p>
+  <img src="//example.com/image.jpg" />
 </body>
 </html>

--- a/spec/meta_inspector/head_links_spec.rb
+++ b/spec/meta_inspector/head_links_spec.rb
@@ -4,12 +4,14 @@ describe MetaInspector do
 
   describe "head_links" do
     let(:page) { MetaInspector.new('http://example.com/head_links') }
+    let(:page_https) { MetaInspector.new('https://example.com/head_links') }
 
     it "#head_links" do
       expect(page.head_links).to eq([
                                         {rel: 'canonical', href: 'http://example.com/canonical-from-head'},
-                                        {rel: 'stylesheet', href: '/stylesheets/screen.css'},
-                                        {rel: 'shortcut icon', href: '/favicon.ico', type: 'image/x-icon'},
+                                        {rel: 'stylesheet', href: 'http://example.com/stylesheets/screen.css'},
+                                        {rel: 'stylesheet', href: 'http://example2.com/stylesheets/screen.css'},
+                                        {rel: 'shortcut icon', href: 'http://example.com/favicon.ico', type: 'image/x-icon'},
                                         {rel: 'shorturl', href: 'http://gu.com/p/32v5a'},
                                         {rel: 'stylesheet', type: 'text/css', href: 'http://foo/print.css', media: 'print', class: 'contrast'}
                                     ])
@@ -17,7 +19,14 @@ describe MetaInspector do
 
     it "#stylesheets" do
       expect(page.stylesheets).to eq([
-                                         {rel: 'stylesheet', href: '/stylesheets/screen.css'},
+                                         {rel: 'stylesheet', href: 'http://example.com/stylesheets/screen.css'},
+                                         {rel: 'stylesheet', href: 'http://example2.com/stylesheets/screen.css'},
+                                         {rel: 'stylesheet', type: 'text/css', href: 'http://foo/print.css', media: 'print', class: 'contrast'}
+                                     ])
+
+      expect(page_https.stylesheets).to eq([
+                                         {rel: 'stylesheet', href: 'https://example.com/stylesheets/screen.css'},
+                                         {rel: 'stylesheet', href: 'https://example2.com/stylesheets/screen.css'},
                                          {rel: 'stylesheet', type: 'text/css', href: 'http://foo/print.css', media: 'print', class: 'contrast'}
                                      ])
     end

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -212,4 +212,26 @@ describe MetaInspector do
       expect(page.images.favicon).to eq(nil)
     end
   end
+
+  describe 'protocol-relative' do
+    before(:each) do
+      @m_http   = MetaInspector.new('http://protocol-relative.com')
+      @m_https  = MetaInspector.new('https://protocol-relative.com')
+    end
+
+    it 'should unrelativize images' do
+      expect(@m_http.images.to_a).to eq(['http://example.com/image.jpg'])
+      expect(@m_https.images.to_a).to eq(['https://example.com/image.jpg'])
+    end
+
+    it 'should unrelativize owner suggested image' do
+      expect(@m_http.images.owner_suggested).to eq('http://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/8/8/1312810126887/gu_192x115.jpg')
+      expect(@m_https.images.owner_suggested).to eq('https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/8/8/1312810126887/gu_192x115.jpg')
+    end
+
+    it 'should unrelativize favicon' do
+      expect(@m_http.images.favicon).to eq('http://static-secure.guim.co.uk/sys-images/favicon.ico')
+      expect(@m_https.images.favicon).to eq('https://static-secure.guim.co.uk/sys-images/favicon.ico')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,7 @@ FakeWeb.register_uri(:get, "http://www.24-horas.mx/mexico-firma-acuerdo-bilatera
 
 #Used to test canonical URLs in head
 FakeWeb.register_uri(:get, "http://example.com/head_links", :response => fixture_file("head_links.response"))
+FakeWeb.register_uri(:get, "https://example.com/head_links", :response => fixture_file("head_links.response"))
 
 # Used to test best_title logic
 FakeWeb.register_uri(:get, "http://example.com/title_in_head", :response => fixture_file("title_in_head.response"))


### PR DESCRIPTION
@jaimeiniesta: regarding #135, I added some tests to TDD this issue, but I realized that they passed w/o any modification. Apparently `Addressable::URI` is in charge of protocol-unrelativize the urls.

I think you can incorporate these tests and perhaps close this ticket.

Juan.