### PR TITLE
Add Faraday::HttpCache support #143

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,11 +376,11 @@ page = MetaInspector.new('http://example.com', download_images: false)
 
 ### Caching responses
 
-MetaInspector can be configured to use [Faraday::HttpCache](https://github.com/plataformatec/faraday-http-cache) to cache page responses. For that you should pass the `faraday_cache_options` option with at least the `:store` key, for example:
+MetaInspector can be configured to use [Faraday::HttpCache](https://github.com/plataformatec/faraday-http-cache) to cache page responses. For that you should pass the `faraday_http_cache` option with at least the `:store` key, for example:
 
 ```ruby
 cache = ActiveSupport::Cache.lookup_store(:file_store, '/tmp/cache')
-page = MetaInspector.new('http://example.com', faraday_cache_options: { store: cache })
+page = MetaInspector.new('http://example.com', faraday_http_cache: { store: cache })
 ```
 
 ## Exception Handling

--- a/README.md
+++ b/README.md
@@ -374,6 +374,15 @@ If you want to disable this, you can specify it like this:
 page = MetaInspector.new('http://example.com', download_images: false)
 ```
 
+### Caching responses
+
+MetaInspector can be configured to use [Faraday::HttpCache](https://github.com/plataformatec/faraday-http-cache) to cache page responses. For that you should pass the `faraday_cache_options` option with at least the `:store` key, for example:
+
+```ruby
+cache = ActiveSupport::Cache.lookup_store(:file_store, '/tmp/cache')
+page = MetaInspector.new('http://example.com', faraday_cache_options: { store: cache })
+```
+
 ## Exception Handling
 
 By default, MetaInspector will raise the exceptions found. We think that this is the safest default: in case the URL you're trying to scrape is unreachable, you should clearly be notified, and treat the exception as needed in your app.

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -33,6 +33,7 @@ module MetaInspector
       @exception_log      = options[:exception_log] || MetaInspector::ExceptionLog.new(warn_level: warn_level)
       @normalize_url      = options[:normalize_url]
       @faraday_options    = options[:faraday_options]
+      @faraday_cache_opts = options[:faraday_cache_options]
       @url                = MetaInspector::URL.new(initial_url, exception_log:      @exception_log,
                                                                 normalize:          @normalize_url)
       @request            = MetaInspector::Request.new(@url,    allow_redirections: @allow_redirections,
@@ -41,7 +42,8 @@ module MetaInspector
                                                                 retries:            @retries,
                                                                 exception_log:      @exception_log,
                                                                 headers:            @headers,
-                                                                faraday_options:    @faraday_options) unless @document
+                                                                faraday_options:    @faraday_options,
+                                                                faraday_cache_opts: @faraday_cache_opts) unless @document
       @parser             = MetaInspector::Parser.new(self,     exception_log:      @exception_log,
                                                                 download_images:    @download_images)
     end

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -33,7 +33,7 @@ module MetaInspector
       @exception_log      = options[:exception_log] || MetaInspector::ExceptionLog.new(warn_level: warn_level)
       @normalize_url      = options[:normalize_url]
       @faraday_options    = options[:faraday_options]
-      @faraday_cache_opts = options[:faraday_cache_options]
+      @faraday_http_cache = options[:faraday_http_cache]
       @url                = MetaInspector::URL.new(initial_url, exception_log:      @exception_log,
                                                                 normalize:          @normalize_url)
       @request            = MetaInspector::Request.new(@url,    allow_redirections: @allow_redirections,
@@ -43,7 +43,7 @@ module MetaInspector
                                                                 exception_log:      @exception_log,
                                                                 headers:            @headers,
                                                                 faraday_options:    @faraday_options,
-                                                                faraday_cache_opts: @faraday_cache_opts) unless @document
+                                                                faraday_http_cache: @faraday_http_cache) unless @document
       @parser             = MetaInspector::Parser.new(self,     exception_log:      @exception_log,
                                                                 download_images:    @download_images)
     end

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'faraday_middleware'
 require 'faraday-cookie_jar'
+require 'faraday-http-cache'
 
 module MetaInspector
 
@@ -18,6 +19,7 @@ module MetaInspector
       @exception_log      = options[:exception_log]
       @headers            = options[:headers]
       @faraday_options    = options[:faraday_options] || {}
+      @faraday_cache_opts = options[:faraday_cache_opts]
 
       response            # request early so we can fail early
     end
@@ -53,6 +55,11 @@ module MetaInspector
         if @allow_redirections
           faraday.use FaradayMiddleware::FollowRedirects, limit: 10
           faraday.use :cookie_jar
+        end
+
+        if @faraday_cache_opts.is_a?(Hash)
+          @faraday_cache_opts[:serializer] ||= Marshal
+          faraday.use Faraday::HttpCache, @faraday_cache_opts
         end
 
         faraday.headers.merge!(@headers || {})

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -19,7 +19,7 @@ module MetaInspector
       @exception_log      = options[:exception_log]
       @headers            = options[:headers]
       @faraday_options    = options[:faraday_options] || {}
-      @faraday_cache_opts = options[:faraday_cache_opts]
+      @faraday_http_cache = options[:faraday_http_cache]
 
       response            # request early so we can fail early
     end
@@ -57,9 +57,9 @@ module MetaInspector
           faraday.use :cookie_jar
         end
 
-        if @faraday_cache_opts.is_a?(Hash)
-          @faraday_cache_opts[:serializer] ||= Marshal
-          faraday.use Faraday::HttpCache, @faraday_cache_opts
+        if @faraday_http_cache.is_a?(Hash)
+          @faraday_http_cache[:serializer] ||= Marshal
+          faraday.use Faraday::HttpCache, @faraday_http_cache
         end
 
         faraday.headers.merge!(@headers || {})

--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.9.0'
   gem.add_dependency 'faraday_middleware', '~> 0.10'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
+  gem.add_dependency 'faraday-http-cache', '~> 1.2.2'
   gem.add_dependency 'addressable', '~> 2.3.5'
   gem.add_dependency 'fastimage'
 

--- a/spec/meta_inspector/meta_inspector_spec.rb
+++ b/spec/meta_inspector/meta_inspector_spec.rb
@@ -4,4 +4,15 @@ describe MetaInspector do
   it "returns a Document" do
     expect(MetaInspector.new('http://example.com').class).to eq(MetaInspector::Document)
   end
+
+  it "cache request" do
+    # Creates a memory cache (a Hash that responds to #read, #write and #delete)
+    cache = Hash.new
+    def cache.read(k) self[k]; end
+    def cache.write(k, v) self[k] = v; end
+
+    expect(MetaInspector.new('http://example.com', warn_level: :store, faraday_cache_options: { store: cache })).to be_ok
+
+    expect(cache.keys).not_to be_empty
+  end
 end

--- a/spec/meta_inspector/meta_inspector_spec.rb
+++ b/spec/meta_inspector/meta_inspector_spec.rb
@@ -11,7 +11,7 @@ describe MetaInspector do
     def cache.read(k) self[k]; end
     def cache.write(k, v) self[k] = v; end
 
-    expect(MetaInspector.new('http://example.com', warn_level: :store, faraday_cache_options: { store: cache })).to be_ok
+    expect(MetaInspector.new('http://example.com', warn_level: :store, faraday_http_cache: { store: cache })).to be_ok
 
     expect(cache.keys).not_to be_empty
   end


### PR DESCRIPTION
This PR adds caching by means of Faraday::HttpCache as you suggested in #143, hope it's useful.

I had problems with the default serializer (JSON) because Net::HTTP does not set the corresponding encoding to the response body (see: https://github.com/plataformatec/faraday-http-cache/issues/38) so I had to use Marshal as the default serializer here.

This PR includes the README and a basic test to verify that it is working.

Juan.