### PR TITLE
Fix tracking issues with #131

### DIFF
--- a/lib/meta_inspector/url.rb
+++ b/lib/meta_inspector/url.rb
@@ -31,18 +31,21 @@ module MetaInspector
 
     def tracked?
       u = parsed(url)
+      return false unless u.query_values
       found_tracking_params = WELL_KNOWN_TRACKING_PARAMS & u.query_values.keys
       return found_tracking_params.any?
     end
 
     def untracked_url
       u = parsed(url)
-      u.query_values = u.query_values.delete_if { |key, _| WELL_KNOWN_TRACKING_PARAMS.include? key }
+      return url unless u.query_values
+      query_values = u.query_values.delete_if { |key, _| WELL_KNOWN_TRACKING_PARAMS.include? key }
+      u.query_values = query_values.length > 0 ? query_values : nil
       u.to_s
     end
 
     def untrack!
-      self.url = untracked_url
+      self.url = untracked_url if tracked?
     end
 
     def url=(new_url)

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -43,6 +43,8 @@ describe MetaInspector::URL do
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&utm_content=1234').untracked_url).to eq('http://example.com/foo?not_utm_thing=bar')
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&utm_campaign=1234').untracked_url).to eq('http://example.com/foo?not_utm_thing=bar')
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&utm_source=1234&utm_medium=5678&utm_term=4321&utm_content=9876&utm_campaign=5436').untracked_url).to eq('http://example.com/foo?not_utm_thing=bar')
+    expect(MetaInspector::URL.new('http://example.com/foo?utm_source=1234&utm_medium=5678&utm_term=4321&utm_content=9876&utm_campaign=5436').untracked_url).to eq('http://example.com/foo')
+    expect(MetaInspector::URL.new('http://example.com/foo').untracked_url).to eq('http://example.com/foo')
   end
 
   it "should remove tracking parameters from url" do
@@ -62,6 +64,18 @@ describe MetaInspector::URL do
     end
   end
 
+  it "should remove all query values when untrack url" do
+    url = MetaInspector::URL.new('http://example.com/foo?utm_campaign=1234')
+    url.untrack!
+    expect(url.url).to eq('http://example.com/foo')
+  end
+
+  it "should untrack untracked url" do
+    url = MetaInspector::URL.new('http://example.com/foo')
+    url.untrack!
+    expect(url.url).to eq('http://example.com/foo')
+  end
+
   it "should say if the url is tracked" do
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&utm_source=1234').tracked?).to be true
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&utm_medium=1234').tracked?).to be true
@@ -75,6 +89,8 @@ describe MetaInspector::URL do
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&not_utm_term=1234').tracked?).to be false
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&not_utm_content=1234').tracked?).to be false
     expect(MetaInspector::URL.new('http://example.com/foo?not_utm_thing=bar&not_utm_campaign=1234').tracked?).to be false
+
+    expect(MetaInspector::URL.new('http://example.com/foo').tracked?).to be false
   end
 
   describe "url=" do


### PR DESCRIPTION
Hi,

I started using `page.tracked?`, `page.untracked_url` and `page.untrack!` and all three fail with URLs that don't have query values, for example:

```ruby
page = MetaInspector.new('http://example.com/foo')
page.tracked?
NoMethodError: undefined method `keys' for nil:NilClass
	from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/metainspector-4.6.1/lib/meta_inspector/url.rb:34:in `tracked?'
```

At the same time, if the URL has only tracking query values, the `untracked_url` method returns the URL with the question mark (?) at the end:

```ruby
page = MetaInspector.new('http://example.com/foo?utm_source=twitter')
page.untracked_url
=> "http://example.com/foo?"
```

I created the missing tests that reproduced those errors and fixed the API.

Hope it helps.

Juan.
