### PR TITLE
Rescue FaradayMiddleware::RedirectLimitReached

### DIFF
--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -39,6 +39,7 @@ module MetaInspector
     def response
       @response ||= fetch
     rescue Faraday::TimeoutError, Faraday::Error::ConnectionFailed, Faraday::SSLError,
+           FaradayMiddleware::RedirectLimitReached,
            RuntimeError, URI::InvalidURIError => e
       @exception_log << e
       nil


### PR DESCRIPTION
Tested with http://blog.developeracademy.co.uk/TakeNote/Default.aspx ([curl output here](https://gist.github.com/dentarg/918951d056058b9350ec))

```ruby
$ bundle exec rake console
[1] pry(main)> page = MetaInspector.new("http://blog.developeracademy.co.uk/TakeNote/Default.aspx", warn_level: :store) ; nil
=> nil
[2] pry(main)> page.exceptions
=> [#<FaradayMiddleware::RedirectLimitReached>, #<FaradayMiddleware::RedirectLimitReached>]
[3] pry(main)>
```

I wanted to make a test for the logger, like the ones in request_spec, but I could not make it work :sob: 

```diff
$ git diff
diff --git a/spec/meta_inspector/redirections_spec.rb b/spec/meta_inspector/redirections_spec.rb
index b268c0c..a0ace97 100644
--- a/spec/meta_inspector/redirections_spec.rb
+++ b/spec/meta_inspector/redirections_spec.rb
@@ -39,6 +39,12 @@ describe MetaInspector do
           perform_request
         }.to raise_error FaradayMiddleware::RedirectLimitReached
       end
+
+      it "logs the error" do
+        perform_request
+
+        expect(logger).to receive(:<<).with(an_instance_of(FaradayMiddleware::RedirectLimitReached))
+      end
     end

     context "when there are cookies required for proper redirection" do
```

also tried with `warn_level: :store`, but it made no difference

```
Failures:

  1) MetaInspector redirections when there are too many redirects logs the error
     Failure/Error:
       response = session.get do |req|
         req.options.timeout      = @connection_timeout
         req.options.open_timeout = @read_timeout

     FaradayMiddleware::RedirectLimitReached:
       too many redirects; last one to: http://example.org/12
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:80:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:82:in `block in perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:78:in `perform_with_redirection'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday_middleware-0.10.0/lib/faraday_middleware/response/follow_redirects.rb:64:in `call'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/request/retry.rb:116:in `call'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/rack_builder.rb:139:in `build_response'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/connection.rb:377:in `run_request'
     # /Users/dentarg/.gem/ruby/2.2.3/gems/faraday-0.9.2/lib/faraday/connection.rb:140:in `get'
     # ./lib/meta_inspector/request.rb:70:in `fetch'
     # ./lib/meta_inspector/request.rb:40:in `response'
     # ./lib/meta_inspector/request.rb:24:in `initialize'
     # ./lib/meta_inspector/document.rb:39:in `new'
     # ./lib/meta_inspector/document.rb:39:in `initialize'
     # ./lib/meta_inspector.rb:21:in `new'
     # ./lib/meta_inspector.rb:21:in `new'
     # ./spec/meta_inspector/redirections_spec.rb:34:in `block (4 levels) in <top (required)>'
     # ./spec/meta_inspector/redirections_spec.rb:44:in `block (4 levels) in <top (required)>'

Finished in 1.38 seconds (files took 0.44322 seconds to load)
134 examples, 1 failure

Failed examples:

rspec ./spec/meta_inspector/redirections_spec.rb:43 # MetaInspector redirections when there are too many redirects logs the error
```