### PR TITLE
Improve parsing of image content

### DIFF
--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -43,7 +43,7 @@ module MetaInspector
     delegate [:url, :scheme, :host, :root_url,
               :tracked?, :untracked_url, :untrack!]   => :@url
 
-    delegate [:content_type, :response]               => :@request
+    delegate :response                                => :@request
 
     delegate [:parsed, :title, :best_title,
               :description, :links,
@@ -71,6 +71,10 @@ module MetaInspector
         'response'      => { 'status'  => response.status,
                              'headers' => response.headers }
       }
+    end
+
+    def content_type
+      @request && @request.content_type
     end
 
     # Returns the contents of the document as a string

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -32,5 +32,17 @@ module MetaInspector
     def parsed
       @parsed ||= Nokogiri::HTML(@document.to_s)
     end
+
+    # Returns true if the content type is an image
+    def image?
+      content_type = @document.content_type
+      return unless content_type
+      content_type.start_with? 'image/'
+    end
+
+    # Returns the url currently parsed
+    def url
+      @document.url
+    end
   end
 end

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -28,6 +28,7 @@ module MetaInspector
       # See doc at http://developers.facebook.com/docs/opengraph/
       # If none found, tries with Twitter image
       def owner_suggested
+        return @main_parser.url if @main_parser.image?
         suggested_img = meta['og:image'] || meta['twitter:image']
         URL.absolutify(suggested_img, base_url) if suggested_img
       end
@@ -79,6 +80,7 @@ module MetaInspector
       private
 
       def images_collection
+        return [@main_parser.url] if @main_parser.image?
         @images_collection ||= absolutified_images
       end
 

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -6,10 +6,12 @@ module MetaInspector
       # Returns the parsed document title, from the content of the <title> tag
       # within the <head> section.
       def title
+        return nil if @main_parser.image?
         @title ||= parsed.css('head title').inner_text rescue nil
       end
 
       def best_title
+        return nil if @main_parser.image?
         @best_title = meta['og:title'] if @main_parser.host =~ /\.youtube\.com$/
         @best_title ||= find_best_title
       end
@@ -18,6 +20,7 @@ module MetaInspector
       # and if not present will guess by looking at the first paragraph
       # with more than 120 characters
       def description
+        return nil if @main_parser.image?
         meta['description'] || secondary_description
       end
 

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -68,6 +68,13 @@ describe MetaInspector do
 
       expect(page.images.size).to eq(11)
     end
+
+    it "uses the fetched url as image if content is an image" do
+      url = "http://pagerankalert.com/image.png"
+      page = MetaInspector.new(url)
+
+      expect(page.images.to_a).to eq([url])
+    end
   end
 
   describe "images.best" do
@@ -95,6 +102,12 @@ describe MetaInspector do
       expect(page.images.best).to eq("http://example.com/largest")
     end
 
+    it "uses the fetched url as image if content type is image" do
+      url = "http://pagerankalert.com/image.png"
+      page = MetaInspector.new(url)
+
+      expect(page.images.best).to eq(url)
+    end
   end
 
   describe "images.owner_suggested" do

--- a/spec/meta_inspector/texts_spec.rb
+++ b/spec/meta_inspector/texts_spec.rb
@@ -6,6 +6,11 @@ describe MetaInspector do
     expect(page.title).to eq('An example page')
   end
 
+  it "has no title if the content is an image" do
+    page = MetaInspector.new('http://pagerankalert.com/image.png')
+    expect(page.title).to be(nil)
+  end
+
   describe '#best_title' do
     it "should find 'head title' when that's the only thing" do
       page = MetaInspector.new('http://example.com/title_in_head')
@@ -48,6 +53,10 @@ describe MetaInspector do
       expect(page.best_title).to eq('Angular 2 Forms')
     end
 
+    it "returns nil if the content is an image" do
+      page = MetaInspector.new('http://pagerankalert.com/image.png')
+      expect(page.best_title).to be(nil)
+    end
   end
 
   describe '#description' do
@@ -60,6 +69,11 @@ describe MetaInspector do
     it "should find a secondary description if no meta description" do
       page = MetaInspector.new('http://theonion-no-description.com')
       expect(page.description).to eq("SAN FRANCISCO—In a move expected to revolutionize the mobile device industry, Apple launched its fastest and most powerful iPhone to date Tuesday, an innovative new model that can only be seen by the company's hippest and most dedicated customers. This is secondary text picked up because of a missing meta description.")
+    end
+
+    it "returns nil if the content is an image" do
+      page = MetaInspector.new('http://pagerankalert.com/image.png')
+      expect(page.description).to be(nil)
     end
   end
 end


### PR DESCRIPTION
I was tracking down a bug in our app where users would paste a url to an
image in a comment field and see a garbled summary of the contents
behind that url. We use metainspector in the backend to scrape urls, and
after digging around a bit I discovered that any url with content type
`image/*` would result in bad descriptions.

So I filed an issue: #168

And then I read the docs (as you do after first filing an issue...),
only to discover that scraping images wasn't really part of the
responsibility of metainspector [1]. Which I agree with, though the
problem for me as a consumer of the gem is that in order to really
figure out if an url serves an image, I have to first fetch it. That
feels like a lot of work, and so I started thinking about ways to make
metainspector work decently when fetching image urls. This commit is a
result of that:

 - Return `nil` for text descriptions, titles and such
 - Return the image url as the only image found

To work around an issue with grabbing content type for documents where a
`document: '<html/>'` option was passed in, I inlined the `content_type`
method instead of delegating it, and added a nil-check.

[Fixes #168]

[1]: https://github.com/jaimeiniesta/metainspector#html-content-only