### PR TITLE
Upgrade faraday-encoding gem and remove warnings

### DIFF
--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -14,19 +14,17 @@ module MetaInspector
     # * normalize_url: true by default
     # * faraday_options: an optional hash of options to pass to Faraday on the request
     def initialize(initial_url, options = {})
-      options             = defaults.merge(options)
-      @connection_timeout = options[:connection_timeout]
-      @read_timeout       = options[:read_timeout]
-      @retries            = options[:retries]
-
       unless options[:html_content_only].nil?
-        @html_content_only = options[:html_content_only]
-
         puts <<-EOS
           DEPRECATION NOTICE: html_content_only is deprecated and turned on by default since 5.1.0,
           this option will be removed in 5.2.0
         EOS
       end
+      options             = defaults.merge(options)
+      @connection_timeout = options[:connection_timeout]
+      @read_timeout       = options[:read_timeout]
+      @retries            = options[:retries]
+      @html_content_only  = options[:html_content_only]
 
       @allow_redirections = options[:allow_redirections]
       @document           = options[:document]

--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday_middleware', '~> 0.10'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0'
   gem.add_dependency 'faraday-http-cache', '~> 1.2'
-  gem.add_dependency 'faraday-encoding', '~> 0.0.2'
+  gem.add_dependency 'faraday-encoding', '~> 0.0.3'
   gem.add_dependency 'addressable', '~> 2.4'
   gem.add_dependency 'fastimage', '~> 1.8.1'
   gem.add_dependency 'nesty', '~> 1.0'

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -79,7 +79,7 @@ describe MetaInspector::Document do
       expect do
         image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png')
         image_url.title
-      end.to raise_error
+      end.to raise_error(MetaInspector::ParserError)
     end
 
     it "should parse images when parse_html_content_type_only is false" do


### PR DESCRIPTION
Hi @jaimeiniesta!

I'm sending this PR with 2 commits that fix 2 different issues:

1) I found a bug in the faraday-encoding gem (see: https://github.com/ma2gedev/faraday-encoding/pull/3) so I upgraded its version in `meta_inspector.gemspec` to 0.0.3.

2) I realized that the new deprecation warning for the :html_content_only option appears not only when you specify that options but always, so I moved its detection before merging the options with the defaults. I also removed a warning about not specifying the error class in a spec.

Hope it helps.

Juan.