### PR TITLE
Fix feed parsing

### DIFF
--- a/lib/meta_inspector/parsers/head_links.rb
+++ b/lib/meta_inspector/parsers/head_links.rb
@@ -32,8 +32,8 @@ module MetaInspector
       private
 
       def parsed_feed(format)
-        feed = parsed.search("//link[@type='application/#{format}+xml']").first
-        feed ? URL.absolutify(feed.attributes['href'].value, base_url) : nil
+        feed = parsed.search("//link[@type='application/#{format}+xml']").find{|link| link.attributes["href"] }
+        feed ? URL.absolutify(feed['href'], base_url) : nil
       end
     end
   end

--- a/spec/fixtures/broken_head_links.response
+++ b/spec/fixtures/broken_head_links.response
@@ -1,0 +1,36 @@
+HTTP/1.1 200 OK
+Server: nginx/0.7.67
+Date: Fri, 18 Nov 2011 21:46:46 GMT
+Content-Type: text/html
+Connection: keep-alive
+Last-Modified: Mon, 14 Nov 2011 16:53:18 GMT
+Content-Length: 4987
+X-Varnish: 2000423390
+Age: 0
+Via: 1.1 varnish
+
+<html>
+  <head>
+    <title>An example page</title>
+    <link rel="alternate" type="application/rss+xml" title="Media RSS feed" />
+    <link href="http://www.guardian.co.uk/media/techcrunch/rss" rel="alternate" type="application/rss+xml" title="TechCrunch RSS feed" />
+    <link
+        rel="canonical"
+        href="http://example.com/canonical-from-head"
+    />
+    <link rel="stylesheet" href="/stylesheets/screen.css">
+    <link rel="stylesheet" href="//example2.com/stylesheets/screen.css">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="shorturl" href="http://gu.com/p/32v5a" />
+    <link
+        rel="stylesheet"
+        type="text/css"
+        href="http://foo/print.css"
+        media="print"
+        class="contrast"
+    />
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>

--- a/spec/meta_inspector/head_links_spec.rb
+++ b/spec/meta_inspector/head_links_spec.rb
@@ -37,6 +37,12 @@ describe MetaInspector do
                                     ])
     end
 
+    context "on page with some broken feed links" do
+      let(:page){ MetaInspector.new('http://example.com/broken_head_links') }
+      it "tries to find correct one" do
+        expect(page.feed).to eq("http://www.guardian.co.uk/media/techcrunch/rss")
+      end
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,7 @@ FakeWeb.register_uri(:get, "http://www.24-horas.mx/mexico-firma-acuerdo-bilatera
 #Used to test canonical URLs in head
 FakeWeb.register_uri(:get, "http://example.com/head_links", :response => fixture_file("head_links.response"))
 FakeWeb.register_uri(:get, "https://example.com/head_links", :response => fixture_file("head_links.response"))
+FakeWeb.register_uri(:get, "http://example.com/broken_head_links", :response => fixture_file("broken_head_links.response"))
 
 # Used to test best_title logic
 FakeWeb.register_uri(:get, "http://example.com/title_in_head", :response => fixture_file("title_in_head.response"))


### PR DESCRIPTION
Hi there,

This pull request fixes the issue when first link does not contain `href` attribute. I know it’s not common, but eg. metainspector raises exception on http://mahdiantigf.blogfa.com/

Cheers,
Michal