### PR TITLE
Add ArgumentError Exception to URL.absolutify. Fixes #150

### DIFF
--- a/lib/meta_inspector/url.rb
+++ b/lib/meta_inspector/url.rb
@@ -62,7 +62,7 @@ module MetaInspector
       else
         Addressable::URI.join(base_url, url).normalize.to_s
       end
-    rescue MetaInspector::ParserError, Addressable::URI::InvalidURIError
+    rescue MetaInspector::ParserError, Addressable::URI::InvalidURIError, ArgumentError
       nil
     end
 

--- a/spec/fixtures/invalid_byte_seq.response
+++ b/spec/fixtures/invalid_byte_seq.response
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx/0.7.67
+Date: Fri, 18 Nov 2011 21:46:46 GMT
+Content-Type: text/html
+Connection: keep-alive
+Last-Modified: Mon, 14 Nov 2011 16:53:18 GMT
+Content-Length: 340
+
+<html>
+  <head>
+    <title>Sample file invalid byte sequence links</title>
+  </head>
+  <body>
+    <ul>
+      <li><a href="http://pagerankalert.posterous.com">blog</a></li>
+      <li><a href="http://element%b3wgarderoby.com/">invalid</a></li>
+      <li><a href="http://twitter.com/pagerankalert">twitter</a></li>
+    </ul>
+  </body>
+</html>

--- a/spec/meta_inspector/links_spec.rb
+++ b/spec/meta_inspector/links_spec.rb
@@ -105,6 +105,12 @@ describe MetaInspector do
       m = MetaInspector.new('http://example.com/invalid_href')
       expect(m.links.non_http).to eq(["skype:joeuser?call", "telnet://telnet.cdrom.com"])
     end
+
+    it "should not crash with links that have invalid byte sequence, filtering them out" do
+      m = MetaInspector.new('http://example.com/invalid_byte_seq')
+      expect(m.links.all).to eq(["http://pagerankalert.posterous.com/", "http://twitter.com/pagerankalert"])
+    end
+
   end
 
   describe 'Relative links' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,7 @@ FakeWeb.register_uri(:get, "http://protocol-relative.com", :response => fixture_
 FakeWeb.register_uri(:get, "https://protocol-relative.com", :response => fixture_file("protocol_relative.response"))
 FakeWeb.register_uri(:get, "http://example.com/nonhttp", :response => fixture_file("nonhttp.response"))
 FakeWeb.register_uri(:get, "http://example.com/invalid_href", :response => fixture_file("invalid_href.response"))
+FakeWeb.register_uri(:get, "http://example.com/invalid_byte_seq", :response => fixture_file("invalid_byte_seq.response"))
 FakeWeb.register_uri(:get, "http://example.com/malformed_href", :response => fixture_file("malformed_href.response"))
 FakeWeb.register_uri(:get, "http://www.youtube.com/watch?v=iaGSSrp49uc", :response => fixture_file("youtube.response"))
 FakeWeb.register_uri(:get, "http://markupvalidator.com/faqs", :response => fixture_file("markupvalidator_faqs.response"))


### PR DESCRIPTION
Hi @jaimeiniesta and @dentarg!

I found that #150 can be fixed adding the ArgumentError exception to URL.absolutify. That makes that Links#all method skips all invalid links and it's a better solution than handling the exception like @dentarg is doing now, that is returning an empty array of links.

Let me know if you want me to add some test to this specific situation.

Juan Schwindt.