### PR TITLE
Return secondary description on empty description

### DIFF
--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -18,7 +18,8 @@ module MetaInspector
       # and if not present will guess by looking at the first paragraph
       # with more than 120 characters
       def description
-        meta['description'] || secondary_description
+        return meta['description'] unless meta['description'].nil? || meta['description'].empty?
+        secondary_description
       end
 
       private

--- a/spec/fixtures/empty_metatag_description.response
+++ b/spec/fixtures/empty_metatag_description.response
@@ -1,0 +1,22 @@
+HTTP/1.1 200 OK
+Date: Fri, 29 Apr 2016 00:27:28 GMT
+Content-Type: text/html; charset=utf-8
+Connection: keep-alive
+X-Powered-By: Express
+Cache-Control: public, max-age=0
+Vary: Accept-Encoding
+Via: 1.1 vegur
+Server: cloudflare-nginx
+CF-RAY: 29aea0e05c720938-DFW
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Disrupting DeAcero, un ejemplo de innovación Disruptive Angels</title>
+<meta name="description" content=""/>
+</head>
+<body>
+<p>Vivimos en una época en la que el término 'Innovación' esta siendo usado a placer por organizaciones de todo tipo. Hace algunos meses en una reunión de trabajo alguien mencionó:"La innovación esta siendo usada como todo aquello que las empresas no saben dónde poner". Mejor no lo pudo haber dicho. Llevamos más de dos años de estar colaborando cercanamente con directores de innovación de decenas de empresas, participando en comisiones industriales enfocadas a la innovación y haciendo conexiones laborales internacionales con expertos en materias de innovación (particularmente innovación abierta), y después de todo, la gran mayoría de las empresas no tienen claro lo que (por lo menos dentro de su organización) es innovación. </p>
+</body>
+</html>

--- a/spec/meta_inspector/texts_spec.rb
+++ b/spec/meta_inspector/texts_spec.rb
@@ -61,5 +61,10 @@ describe MetaInspector do
       page = MetaInspector.new('http://theonion-no-description.com')
       expect(page.description).to eq("SAN FRANCISCO—In a move expected to revolutionize the mobile device industry, Apple launched its fastest and most powerful iPhone to date Tuesday, an innovative new model that can only be seen by the company's hippest and most dedicated customers. This is secondary text picked up because of a missing meta description.")
     end
+
+    it 'should find first paragraph if meta description is empty' do
+      expect(MetaInspector.new('http://example.com/empty-meta-description').description)
+        .to eq("Vivimos en una época en la que el término 'Innovación' esta siendo usado a placer por organizaciones de todo tipo. Hace algunos meses en una reunión de trabajo alguien mencionó:\"La innovación esta siendo usada como todo aquello que las empresas no saben dónde poner\". Mejor no lo pudo haber dicho. Llevamos más de dos años de estar colaborando cercanamente con directores de innovación de decenas de empresas, participando en comisiones industriales enfocadas a la innovación y haciendo conexiones laborales internacionales con expertos en materias de innovación (particularmente innovación abierta), y después de todo, la gran mayoría de las empresas no tienen claro lo que (por lo menos dentro de su organización) es innovación. ")
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,3 +112,6 @@ FakeWeb.register_uri(:get, "http://example.com/~", :response => fixture_file("ex
 
 # Example to test correct encoding
 FakeWeb.register_uri(:get, "http://example-rtl.com/", :response => fixture_file("encoding.response"))
+
+# Example used to test empty description metatags
+FakeWeb.register_uri(:get, "http://example.com/empty-meta-description", :response => fixture_file("empty_metatag_description.response"))


### PR DESCRIPTION
`page.description` returns an empty string when meta description is empty

```
page = MetaInspector.new('http://blog.disruptiveangels.com/disrupting-deacero/')
page.description
=> ""
```

This makes it return `secondary_description` when empty.