### PR TITLE
parsing title tag which might not be inside <head>

### DIFF
--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -6,7 +6,7 @@ module MetaInspector
       # Returns the parsed document title, from the content of the <title> tag
       # within the <head> section.
       def title
-        @title ||= parsed.css('head title').inner_text rescue nil
+        @title ||= parsed.css('title').inner_text rescue nil
       end
 
       def best_title


### PR DESCRIPTION
I faced an issue with this webpage : http://sellingtothepoint.com/

Where the title tag was given outside the <head> tag


Here is a proposed fix for the same.