### PR TITLE
Add method best_description

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ page.feed                # Get rss or atom links in meta data fields as array
 page.title               # title of the page from the head section, as string
 page.best_title          # best title of the page, from a selection of candidates
 page.description         # returns the meta description, or the first long paragraph if no meta description is found
+page.best_description    # returns the first non-empty description between the following candidates: standard meta description, og:description, twitter:description, the first long paragraph, empty string if all are empty
 ```
 
 ### Links

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -46,7 +46,7 @@ module MetaInspector
     delegate [:content_type, :response]               => :@request
 
     delegate [:parsed, :title, :best_title,
-              :description, :links,
+              :description, :best_description, :links,
               :images, :feed, :charset, :meta_tags,
               :meta_tag, :meta, :favicon,
               :head_links, :stylesheets, :canonicals] => :@parser
@@ -54,22 +54,23 @@ module MetaInspector
     # Returns all document data as a nested Hash
     def to_hash
       {
-        'url'           => url,
-        'scheme'        => scheme,
-        'host'          => host,
-        'root_url'      => root_url,
-        'title'         => title,
-        'best_title'    => best_title,
-        'description'   => description,
-        'links'         => links.to_hash,
-        'images'        => images.to_a,
-        'charset'       => charset,
-        'feed'          => feed,
-        'content_type'  => content_type,
-        'meta_tags'     => meta_tags,
-        'favicon'       => images.favicon,
-        'response'      => { 'status'  => response.status,
-                             'headers' => response.headers }
+        'url'              => url,
+        'scheme'           => scheme,
+        'host'             => host,
+        'root_url'         => root_url,
+        'title'            => title,
+        'best_title'       => best_title,
+        'description'      => description,
+        'best_description' => best_description,
+        'links'            => links.to_hash,
+        'images'           => images.to_a,
+        'charset'          => charset,
+        'feed'             => feed,
+        'content_type'     => content_type,
+        'meta_tags'        => meta_tags,
+        'favicon'          => images.favicon,
+        'response'         => { 'status'  => response.status,
+                                'headers' => response.headers }
       }
     end
 

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -21,12 +21,12 @@ module MetaInspector
     end
 
     extend Forwardable
-    delegate [:url, :scheme, :host]                          => :@document
-    delegate [:meta_tags, :meta_tag, :meta, :charset]        => :@meta_tag_parser
-    delegate [:head_links, :stylesheets, :canonicals, :feed] => :@head_links_parser
-    delegate [:links, :base_url]                             => :@links_parser
-    delegate :images                                         => :@images_parser
-    delegate [:title, :best_title, :description]             => :@texts_parser
+    delegate [:url, :scheme, :host]                                 => :@document
+    delegate [:meta_tags, :meta_tag, :meta, :charset]               => :@meta_tag_parser
+    delegate [:head_links, :stylesheets, :canonicals, :feed]        => :@head_links_parser
+    delegate [:links, :base_url]                                    => :@links_parser
+    delegate :images                                                => :@images_parser
+    delegate [:title, :best_title, :description, :best_description] => :@texts_parser
 
     # Returns the whole parsed document
     def parsed

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -22,6 +22,22 @@ module MetaInspector
         secondary_description
       end
 
+      # A description getter that returns the first non-nill description
+      # from the following candidates:
+      # - the standard meta description
+      # - the og:description meta tag
+      # - the twitter:description meta tag
+      # - the first paragraph with more than 120 characters
+      def best_description
+        candidates = [
+          meta['description'],
+          meta['og:description'],
+          meta['twitter:description'],
+          secondary_description
+        ]
+        candidates.find { |x| !x.to_s.empty? } || ''
+      end
+
       private
 
       # Look for candidates and pick the longest one

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -27,6 +27,7 @@ describe MetaInspector::Document do
                             "title"           => "PageRankAlert.com :: Track your PageRank changes & receive alerts",
                             "best_title"      => "PageRankAlert.com :: Track your PageRank changes & receive alerts",
                             "description"     => "Track your PageRank(TM) changes and receive alerts by email",
+                            "best_description"=> "Track your PageRank(TM) changes and receive alerts by email",
                             "favicon"         => "http://pagerankalert.com/src/favicon.ico",
                             "links"           => {
                                                     'internal' => ["http://pagerankalert.com/",

--- a/spec/fixtures/desc_in_meta.response
+++ b/spec/fixtures/desc_in_meta.response
@@ -1,0 +1,23 @@
+HTTP/1.1 200 OK
+Age: 13
+Cache-Control: max-age=120
+Content-Type: text/html
+Date: Mon, 06 Jan 2014 12:47:42 GMT
+Expires: Mon, 06 Jan 2014 12:49:28 GMT
+Server: Apache/2.2.14 (Ubuntu)
+Vary: Accept-Encoding
+Via: 1.1 varnish
+X-Powered-By: PHP/5.3.2-1ubuntu4.22
+X-Varnish: 1188792404 1188790413
+Content-Length: 40571
+Connection: keep-alive
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml">
+  <head>
+    <meta name="description" content="the standard description" />
+</head>
+  <body>
+    <p>A sample page with description in standard meta tag</p>
+  </body>
+</html>

--- a/spec/fixtures/desc_in_og.response
+++ b/spec/fixtures/desc_in_og.response
@@ -1,0 +1,23 @@
+HTTP/1.1 200 OK
+Age: 13
+Cache-Control: max-age=120
+Content-Type: text/html
+Date: Mon, 06 Jan 2014 12:47:42 GMT
+Expires: Mon, 06 Jan 2014 12:49:28 GMT
+Server: Apache/2.2.14 (Ubuntu)
+Vary: Accept-Encoding
+Via: 1.1 varnish
+X-Powered-By: PHP/5.3.2-1ubuntu4.22
+X-Varnish: 1188792404 1188790413
+Content-Length: 40571
+Connection: keep-alive
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml">
+  <head>
+    <meta property="og:description" content="the og description" />
+</head>
+  <body>
+    <p>A sample page with description in og meta tag</p>
+  </body>
+</html>

--- a/spec/fixtures/desc_in_twitter.response
+++ b/spec/fixtures/desc_in_twitter.response
@@ -1,0 +1,23 @@
+HTTP/1.1 200 OK
+Age: 13
+Cache-Control: max-age=120
+Content-Type: text/html
+Date: Mon, 06 Jan 2014 12:47:42 GMT
+Expires: Mon, 06 Jan 2014 12:49:28 GMT
+Server: Apache/2.2.14 (Ubuntu)
+Vary: Accept-Encoding
+Via: 1.1 varnish
+X-Powered-By: PHP/5.3.2-1ubuntu4.22
+X-Varnish: 1188792404 1188790413
+Content-Length: 40571
+Connection: keep-alive
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml">
+  <head>
+    <meta property="twitter:description" content="the twitter description" />
+</head>
+  <body>
+    <p>A sample page with description in og meta tag</p>
+  </body>
+</html>

--- a/spec/meta_inspector/texts_spec.rb
+++ b/spec/meta_inspector/texts_spec.rb
@@ -67,4 +67,36 @@ describe MetaInspector do
         .to eq("Vivimos en una época en la que el término 'Innovación' esta siendo usado a placer por organizaciones de todo tipo. Hace algunos meses en una reunión de trabajo alguien mencionó:\"La innovación esta siendo usada como todo aquello que las empresas no saben dónde poner\". Mejor no lo pudo haber dicho. Llevamos más de dos años de estar colaborando cercanamente con directores de innovación de decenas de empresas, participando en comisiones industriales enfocadas a la innovación y haciendo conexiones laborales internacionales con expertos en materias de innovación (particularmente innovación abierta), y después de todo, la gran mayoría de las empresas no tienen claro lo que (por lo menos dentro de su organización) es innovación. ")
     end
   end
+
+  describe "#best_description" do
+    it "should return the standard description meta tag content if present" do
+      page = MetaInspector.new('http://example.com/desc_in_meta')
+
+      expect(page.best_description).to eq("the standard description")
+    end
+
+    it "should return the og description if standard meta tag is not present" do
+      page = MetaInspector.new('http://example.com/desc_in_og')
+
+      expect(page.best_description).to eq("the og description")
+    end
+
+    it "should return the twitter description if standard and og tag not present" do
+      page = MetaInspector.new('http://example.com/desc_in_twitter')
+
+      expect(page.best_description).to eq("the twitter description")
+    end
+
+    it "should return the secondary description if no meta tag is present" do
+      page = MetaInspector.new('http://theonion-no-description.com')
+
+      expect(page.best_description).to eq("SAN FRANCISCO—In a move expected to revolutionize the mobile device industry, Apple launched its fastest and most powerful iPhone to date Tuesday, an innovative new model that can only be seen by the company's hippest and most dedicated customers. This is secondary text picked up because of a missing meta description.")
+    end
+
+    it "should return an empty string by default" do
+      page = MetaInspector.new('http://example.com/empty')
+
+      expect(page.best_description).to eq("")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,11 @@ FakeWeb.register_uri(:get, "http://example.com/title_not_present", :response => 
 # best_title now has specific logic for youtube
 FakeWeb.register_uri(:get, "http://www.youtube.com/watch?v=short_title", :response => fixture_file("youtube_short_title.response"))
 
+# Used to test best_description logic
+FakeWeb.register_uri(:get, "http://example.com/desc_in_meta", :response => fixture_file("desc_in_meta.response"))
+FakeWeb.register_uri(:get, "http://example.com/desc_in_og", :response => fixture_file("desc_in_og.response"))
+FakeWeb.register_uri(:get, "http://example.com/desc_in_twitter", :response => fixture_file("desc_in_twitter.response"))
+
 # These are older fixtures
 FakeWeb.register_uri(:get, "http://pagerankalert.com", :response => fixture_file("pagerankalert.com.response"))
 FakeWeb.register_uri(:get, "http://pagerankalert-shortcut.com", :response => fixture_file("pagerankalert-shortcut.com.response"))


### PR DESCRIPTION
Add a method best_description to the TextsParser to retreive the first non-empty description between meta description, og:description, twitter:description and secondary_description.

This PR implements the solution discussed in #181 