### PR TITLE
Refactor `description` and `best_description`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ page.feed                # Get rss or atom links in meta data fields as array
 ```ruby
 page.title               # title of the page from the head section, as string
 page.best_title          # best title of the page, from a selection of candidates
-page.description         # returns the meta description, or the first long paragraph if no meta description is found
-page.best_description    # returns the first non-empty description between the following candidates: standard meta description, og:description, twitter:description, the first long paragraph, empty string if all are empty
+page.description         # returns the meta description
+page.best_description    # returns the first non-empty description between the following candidates: standard meta description, og:description, twitter:description, the first long paragraph
 ```
 
 ### Links

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -14,12 +14,9 @@ module MetaInspector
         @best_title ||= find_best_title
       end
 
-      # A description getter that first checks for a meta description
-      # and if not present will guess by looking at the first paragraph
-      # with more than 120 characters
+      # Returns the meta description, if present
       def description
-        return meta['description'] unless meta['description'].nil? || meta['description'].empty?
-        secondary_description
+        @description ||= meta['description']
       end
 
       # A description getter that returns the first non-nill description
@@ -29,13 +26,7 @@ module MetaInspector
       # - the twitter:description meta tag
       # - the first paragraph with more than 120 characters
       def best_description
-        candidates = [
-          meta['description'],
-          meta['og:description'],
-          meta['twitter:description'],
-          secondary_description
-        ]
-        candidates.find { |x| !x.to_s.empty? } || ''
+        @best_description ||= find_best_description
       end
 
       private
@@ -57,6 +48,16 @@ module MetaInspector
         candidates.uniq!
         candidates.sort_by! { |t| -t.length }
         candidates.first
+      end
+
+      def find_best_description
+        candidates = [
+          meta['description'],
+          meta['og:description'],
+          meta['twitter:description'],
+          secondary_description
+        ]
+        candidates.find { |x| !x.to_s.empty? }
       end
 
       # Look for the first <p> block with 120 characters or more

--- a/spec/meta_inspector/texts_spec.rb
+++ b/spec/meta_inspector/texts_spec.rb
@@ -47,24 +47,19 @@ describe MetaInspector do
       page = MetaInspector.new('http://www.youtube.com/watch?v=short_title')
       expect(page.best_title).to eq('Angular 2 Forms')
     end
-
   end
 
   describe '#description' do
     it "should find description from meta description" do
-      page = MetaInspector.new('http://www.youtube.com/watch?v=iaGSSrp49uc')
+      page = MetaInspector.new('http://example.com/desc_in_meta')
 
-      expect(page.description).to eq("This is Youtube")
+      expect(page.description).to eq("the standard description")
     end
 
-    it "should find a secondary description if no meta description" do
-      page = MetaInspector.new('http://theonion-no-description.com')
-      expect(page.description).to eq("SAN FRANCISCO—In a move expected to revolutionize the mobile device industry, Apple launched its fastest and most powerful iPhone to date Tuesday, an innovative new model that can only be seen by the company's hippest and most dedicated customers. This is secondary text picked up because of a missing meta description.")
-    end
+    it "should be nil if no meta description" do
+      page = MetaInspector.new('http://example.com/empty')
 
-    it 'should find first paragraph if meta description is empty' do
-      expect(MetaInspector.new('http://example.com/empty-meta-description').description)
-        .to eq("Vivimos en una época en la que el término 'Innovación' esta siendo usado a placer por organizaciones de todo tipo. Hace algunos meses en una reunión de trabajo alguien mencionó:\"La innovación esta siendo usada como todo aquello que las empresas no saben dónde poner\". Mejor no lo pudo haber dicho. Llevamos más de dos años de estar colaborando cercanamente con directores de innovación de decenas de empresas, participando en comisiones industriales enfocadas a la innovación y haciendo conexiones laborales internacionales con expertos en materias de innovación (particularmente innovación abierta), y después de todo, la gran mayoría de las empresas no tienen claro lo que (por lo menos dentro de su organización) es innovación. ")
+      expect(page.description).to be(nil)
     end
   end
 
@@ -93,10 +88,10 @@ describe MetaInspector do
       expect(page.best_description).to eq("SAN FRANCISCO—In a move expected to revolutionize the mobile device industry, Apple launched its fastest and most powerful iPhone to date Tuesday, an innovative new model that can only be seen by the company's hippest and most dedicated customers. This is secondary text picked up because of a missing meta description.")
     end
 
-    it "should return an empty string by default" do
+    it "should return nil by default" do
       page = MetaInspector.new('http://example.com/empty')
 
-      expect(page.best_description).to eq("")
+      expect(page.best_description).to be(nil)
     end
   end
 end


### PR DESCRIPTION
- `description` will only return the meta description if present.
- `best_description` will try several candidates, return nil if no match.

Related to https://github.com/jaimeiniesta/metainspector/pull/197
and #181