### PR TITLE
Update faraday_middleware version due to #201

### DIFF
--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'nokogiri', '~> 1.6'
   gem.add_dependency 'faraday', '~> 0.9'
-  gem.add_dependency 'faraday_middleware', '~> 0.10'
+  gem.add_dependency 'faraday_middleware', '~> 0.11'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0'
   gem.add_dependency 'faraday-http-cache', '~> 1.2'
   gem.add_dependency 'faraday-encoding', '~> 0.0.3'


### PR DESCRIPTION
Fixes #201 

Redirections fix introduced in `gem 'faraday_middleware', '~> 0.11'`, so we want to use it.

It should be also merged in v4.7.2, right? (because my project is resolved to v4.7.2, not v5.4.0)