### PR TITLE
Add presence validation for empty string on meta tags image values

### DIFF
--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -28,7 +28,7 @@ module MetaInspector
       # See doc at http://developers.facebook.com/docs/opengraph/
       # If none found, tries with Twitter image
       def owner_suggested
-        suggested_img = meta['og:image'] || meta['twitter:image']
+        suggested_img = content_of(meta['og:image']) || content_of(meta['twitter:image'])
         URL.absolutify(suggested_img, base_url) if suggested_img
       end
 
@@ -88,6 +88,11 @@ module MetaInspector
 
       def parsed_images
         cleanup(parsed.search('//img/@src'))
+      end
+
+      def content_of(content)
+        return nil if content.nil? || content.empty?
+        content
       end
     end
   end

--- a/spec/fixtures/meta_tags_empty.response
+++ b/spec/fixtures/meta_tags_empty.response
@@ -1,0 +1,53 @@
+HTTP/1.1 200 OK
+Age: 13
+Cache-Control: max-age=120
+Content-Type: text/html
+Date: Mon, 06 Jan 2014 12:47:42 GMT
+Expires: Mon, 06 Jan 2014 12:49:28 GMT
+Server: Apache/2.2.14 (Ubuntu)
+Vary: Accept-Encoding
+Via: 1.1 varnish
+X-Powered-By: PHP/5.3.2-1ubuntu4.22
+X-Varnish: 1188792404 1188790413
+Content-Length: 40571
+Connection: keep-alive
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml">
+  <head>
+    <!-- meta name examples -->
+
+    <meta name="keywords"       content="" />
+    <meta name="description"    content="" />
+    <meta name="author"         content="" />
+    <meta name="robots"         content="" />
+    <meta name="revisit"        content="" />
+    <meta name="DC.date.issued" content="">
+
+    <!-- meta http-equiv examples -->
+
+    <meta http-equiv="Content-Type"       content="text/html; charset=UTF-8">
+    <meta http-equiv="Content-Style-Type" content="text/css" />
+
+    <!-- meta charset examples -->
+
+    <meta charset="UTF-8" />
+
+    <!-- meta property examples -->
+
+    <meta property="og:title" content="" />
+    <meta property="og:type" content="" />
+    <meta property="og:url" content="" />
+
+    <meta property="og:image" content="" />
+    <meta property="og:image:width" content="" />
+    <meta property="og:image:height" content="" />
+
+    <meta property="twitter:image" content="" />
+
+  </head>
+  <body>
+    <p>A sample page with many types of empty meta tags and an image to fallback to</p>
+    <img src="/100x100" />
+  </body>
+</html>

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -88,6 +88,12 @@ describe MetaInspector do
       expect(page.images.best).to eq("http://example.com/100x100")
     end
 
+    it "should find image when og:image and twitter:image metatags are present but empty" do
+      page = MetaInspector.new('http://example.com/meta_tags_empty')
+
+      expect(page.images.best).to eq("http://example.com/100x100")
+    end
+
     it "should find image when some img tag has no src attribute" do
       page = MetaInspector.new('http://example.com/malformed_image_in_html')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,5 +72,6 @@ RSpec.configure do |config|
     stub_request(:get, "https://protocol-relative.com").to_return(fixture_file("protocol_relative.response"))
     stub_request(:get, "https://twitter.com/markupvalidator").to_return(fixture_file("twitter_markupvalidator.response"))
     stub_request(:get, "https://www.facebook.com/").to_return(fixture_file("https.facebook.com.response"))
+    stub_request(:get, "http://example.com/meta_tags_empty").to_return(fixture_file("meta_tags_empty.response"))
   end
 end


### PR DESCRIPTION
When the meta tags for images exist but are empty `#owner_suggested`
returned the `base_url` concatenated with an empty string which was not an
image. This patch discards the empty string as a valid present value.