### PR TITLE
Explicitly require to define FaradayMiddleware::RedirectLimitReached

### DIFF
--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'faraday_middleware'
+require 'faraday_middleware/response/follow_redirects'
 require 'faraday-cookie_jar'
 require 'faraday-http-cache'
 require 'faraday/encoding'


### PR DESCRIPTION
This change fixes an error of `NameError: uninitialized constant FaradayMiddleware::RedirectLimitReached`. 

The issue is that `MetaInspector::Request` uses `FaradayMiddleware::RedirectLimitReached` as below, which can result in `NameError: uninitialized constant` when `FaradayMiddleware::FollowRedirects` is not loaded. 

https://github.com/jaimeiniesta/metainspector/blob/8df66c0439fe9fbca98f7b167e6648126768302d/lib/meta_inspector/request.rb#L44

This happens because `faraday_middleware` auto-loads `FaradayMiddleware::FollowRedirects` class 
as below, which also defines `FaradayMiddleware::RedirectLimitReached` error class in the same file. 

https://github.com/lostisland/faraday_middleware/blob/895a55511699950c535d29291aa8e9dc70b7b6d4/lib/faraday_middleware.rb#L18

Explicit requiring of the file will fix the problem. 