### PR TITLE
Prefer OG tags for title and author

### DIFF
--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -78,7 +78,6 @@ module MetaInspector
         return nil if candidates.empty?
         candidates.map! { |c| c.gsub(/\s+/, ' ') }
         candidates.uniq!
-        candidates.sort_by! { |t| -t.length }
         candidates.first
       end
 

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -57,10 +57,7 @@ module MetaInspector
         candidates.flatten!
         candidates.compact!
         candidates.map! { |c| (c.respond_to? :inner_text) ? c.inner_text : c }
-        candidates.map! { |c| c.strip }
-        return nil if candidates.empty?
-        candidates.map! { |c| c.gsub(/\s+/, ' ') }
-        candidates.uniq!
+        candidates.map! { |c| c.strip.gsub(/\s+/, ' ') }
         candidates.first
       end
 
@@ -74,10 +71,7 @@ module MetaInspector
         candidates.flatten!
         candidates.compact!
         candidates.map! { |c| (c.respond_to? :inner_text) ? c.inner_text : c }
-        candidates.map! { |c| c.strip }
-        return nil if candidates.empty?
-        candidates.map! { |c| c.gsub(/\s+/, ' ') }
-        candidates.uniq!
+        candidates.map! { |c| c.strip.gsub(/\s+/, ' ') }
         candidates.first
       end
 

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -10,7 +10,6 @@ module MetaInspector
       end
 
       def best_title
-        @best_title = meta['og:title'] if @main_parser.host =~ /\.youtube\.com$/
         @best_title ||= find_best_title
       end
 
@@ -46,12 +45,13 @@ module MetaInspector
 
       private
 
-      # Look for candidates and pick the longest one
+      # Look for candidates per list of priority
       def find_best_title
         candidates = [
+            meta['title'],
+            meta['og:title'],
             parsed.css('head title'),
             parsed.css('body title'),
-            meta['og:title'],
             parsed.css('h1').first
         ]
         candidates.flatten!
@@ -61,7 +61,6 @@ module MetaInspector
         return nil if candidates.empty?
         candidates.map! { |c| c.gsub(/\s+/, ' ') }
         candidates.uniq!
-        candidates.sort_by! { |t| -t.length }
         candidates.first
       end
 

--- a/spec/fixtures/title_best_choice.response
+++ b/spec/fixtures/title_best_choice.response
@@ -27,7 +27,7 @@ Connection: keep-alive
 
     </title>
 
-    <meta property="og:title" content="This OG title is long, but not long enough" />
+    <meta property="og:title" content="This OG title is the best choice, as per web standards." />
 
 
 

--- a/spec/meta_inspector/texts_spec.rb
+++ b/spec/meta_inspector/texts_spec.rb
@@ -29,7 +29,7 @@ describe MetaInspector do
 
     it "should choose the longest candidate from the available options" do
       page = MetaInspector.new('http://example.com/title_best_choice')
-      expect(page.best_title).to eq('This title came from the first h1 and should be the longest of them all, so should be chosen')
+      expect(page.best_title).to eq('This OG title is the best choice, as per web standards.')
     end
 
     it "should strip leading and trailing whitespace and all line breaks" do
@@ -40,12 +40,6 @@ describe MetaInspector do
     it "should return nil if none of the candidates are present" do
       page = MetaInspector.new('http://example.com/title_not_present')
       expect(page.best_title).to be(nil)
-    end
-
-    it "should use the og:title for youtube in preference to h1" do
-      #youtube has a h1 value of 'This video is unavailable.' which is unhelpful
-      page = MetaInspector.new('http://www.youtube.com/watch?v=short_title')
-      expect(page.best_title).to eq('Angular 2 Forms')
     end
   end
 


### PR DESCRIPTION
This PR makes `best_title` and `best_author` work by order of preference, rather than length of the candidates.

The use case that drove me to this was dealing with a page with long `title` tags within `svg` elements throughout the body. Namely, this one: https://ohws.prospective.ch/public/v1/jobs/972cec5a-4a6c-41a9-a0d2-d2db7de2ca60

Let me know if you have any questions, or wish to debate this approach.