### PR TITLE
Add Option for Force Encoding Before Parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 *.gem
 .bundle
 .rvmrc

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -18,6 +18,7 @@ module MetaInspector
       @connection_timeout = options[:connection_timeout]
       @read_timeout       = options[:read_timeout]
       @retries            = options[:retries]
+      @encoding           = options[:encoding]
 
       @allow_redirections     = options[:allow_redirections]
       @allow_non_html_content = options[:allow_non_html_content]
@@ -28,14 +29,18 @@ module MetaInspector
       @normalize_url      = options[:normalize_url]
       @faraday_options    = options[:faraday_options]
       @faraday_http_cache = options[:faraday_http_cache]
-      @url                = MetaInspector::URL.new(initial_url, normalize:          @normalize_url)
-      @request            = MetaInspector::Request.new(@url,    allow_redirections: @allow_redirections,
-                                                                connection_timeout: @connection_timeout,
-                                                                read_timeout:       @read_timeout,
-                                                                retries:            @retries,
-                                                                headers:            @headers,
-                                                                faraday_options:    @faraday_options,
-                                                                faraday_http_cache: @faraday_http_cache) unless @document
+      @url                = MetaInspector::URL.new(initial_url, normalize: @normalize_url)
+      @request            = MetaInspector::Request.new(
+                              @url,
+                              allow_redirections: @allow_redirections,
+                              connection_timeout: @connection_timeout,
+                              encoding:           @encoding,
+                              read_timeout:       @read_timeout,
+                              retries:            @retries,
+                              headers:            @headers,
+                              faraday_options:    @faraday_options,
+                              faraday_http_cache: @faraday_http_cache
+                            ) unless @document
       @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images)
     end
 

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -17,6 +17,7 @@ module MetaInspector
 
       @allow_redirections = options[:allow_redirections]
       @connection_timeout = options[:connection_timeout]
+      @encoding           = options[:encoding]
       @read_timeout       = options[:read_timeout]
       @retries            = options[:retries]
       @headers            = options[:headers]
@@ -30,7 +31,10 @@ module MetaInspector
     delegate :url => :@url
 
     def read
-      response.body.tr("\000", '') if response
+      return unless response
+      body = response.body
+      body = body.encode!(@encoding, @encoding, :invalid => :replace) if @encoding
+      body.tr("\000", '')
     end
 
     def content_type

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -13,6 +13,18 @@ describe MetaInspector::Request do
 
       expect(page_request.read[0..14]).to eq("<!DOCTYPE html>")
     end
+
+    it "should handle invalid byte sequences gracefully" do
+      page_request =
+        MetaInspector::Request.new(
+          url('http://example.com/invalid_utf8_byte_seq'),
+          encoding: "UTF-8"
+        )
+
+       expect do
+        page_request.read
+      end.to_not raise_error
+    end
   end
 
   describe "response" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ RSpec.configure do |config|
     stub_request(:get, "http://example.com/empty").to_return(fixture_file("empty_page.response"))
     stub_request(:get, "http://example.com/head_links").to_return(fixture_file("head_links.response"))
     stub_request(:get, "http://example.com/invalid_byte_seq").to_return(fixture_file("invalid_byte_seq.response"))
+    stub_request(:get, "http://example.com/invalid_utf8_byte_seq").to_return(body: "hi \255")
     stub_request(:get, "http://example.com/invalid_href").to_return(fixture_file("invalid_href.response"))
     stub_request(:get, "http://example.com/largest_image_in_html").to_return(fixture_file("largest_image_in_html.response"))
     stub_request(:get, "http://example.com/largest_image_using_image_size").to_return(fixture_file("largest_image_using_image_size.response"))


### PR DESCRIPTION
Adds an option to force encoding prior to parsing. Combines PRs https://github.com/jaimeiniesta/metainspector/pull/231 and https://github.com/jaimeiniesta/metainspector/pull/235.

* Add option to force encoding prior to parsing.
* Add specs to test force encoding
* Update gitignore to include *.DS_Store