### PR TITLE
MetaInspector::NonHtmlError exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ Web page scraping is tricky, you can expect to find different exceptions during 
 
 * `MetaInspector::TimeoutError`. When fetching a web page has taken too long.
 * `MetaInspector::RequestError`. When there has been an error on the request phase. Examples: page not found, SSL failure, invalid URI.
-* `MetaInspector::ParserError`. When there has been an error parsing the contents of the page. Example: trying to parse an image file.
+* `MetaInspector::ParserError`. When there has been an error parsing the contents of the page.
+* `MetaInspector::NonHtmlError`. When the contents of the page was not HTML. See also the `allow_non_html_content` option
 
 ## Examples
 

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -105,7 +105,7 @@ module MetaInspector
 
     def document
       @document ||= if !allow_non_html_content && !content_type.nil? && content_type != 'text/html'
-        fail MetaInspector::ParserError.new "The url provided contains #{content_type} content instead of text/html content"
+        fail MetaInspector::NonHtmlError.new "The url provided contains #{content_type} content instead of text/html content"
       else
         @request.read
       end

--- a/lib/meta_inspector/errors.rb
+++ b/lib/meta_inspector/errors.rb
@@ -10,4 +10,6 @@ module MetaInspector
   class RequestError < Error; end
 
   class ParserError < Error; end
+
+  class NonHtmlError < ParserError; end
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -82,14 +82,14 @@ describe MetaInspector::Document do
       expect do
         image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png')
         image_url.title
-      end.to raise_error(MetaInspector::ParserError)
+      end.to raise_error(MetaInspector::NonHtmlError)
     end
 
     it "should not allow non-html content type when explicitly disallowed" do
       expect do
         image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png', allow_non_html_content: false)
         image_url.title
-      end.to raise_error(MetaInspector::ParserError)
+      end.to raise_error(MetaInspector::NonHtmlError)
     end
 
     it "should allow non-html content type when explicitly allowed" do


### PR DESCRIPTION
Hey there!

When Parser fails because the content is not "text/html" I propose to raise `MetaInspector::NonHtmlError` instead of `MetaInspector::ParserError`.

It makes sense so we can differentiate situation when content type is something else than HTML or when the error is something else (wrong scheme ...). For example in my case I just ignore non-html content, but raise an alert when there is an error I should be investigating.

For backward compatibility `MetaInspector::NonHtmlError` inherits from `MetaInspector::ParserError`.