### PR TITLE
Upgrade vulnerable nokogiri to 1.10.x and webmock to run with ruby 2.6.x

### DIFF
--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MetaInspector::VERSION
 
-  gem.add_dependency 'nokogiri', '~> 1.8.5'
+  gem.add_dependency 'nokogiri', '~> 1.10.4'
   gem.add_dependency 'faraday', '~> 0.15.3'
   gem.add_dependency 'faraday_middleware', '~> 0.12.2'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'nesty', '~> 1.0.2'
 
   gem.add_development_dependency 'rspec', '~> 3.8.0'
-  gem.add_development_dependency 'webmock', '~> 3.4.2'
+  gem.add_development_dependency 'webmock', '~> 3.7.6'
   gem.add_development_dependency 'awesome_print', '~> 1.8.0'
   gem.add_development_dependency 'rake', '~> 12.3.1'
   gem.add_development_dependency 'pry', '~> 0.12.2'


### PR DESCRIPTION
Nokogiri 1.8.x has vulnerabilities and webmock didn't work with ruby 2.6.x