### PR TITLE
WIP: Several improvements to metainspector image downloading

### DIFF
--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -26,6 +26,7 @@ module MetaInspector
       @document           = options[:document]
       @download_images    = options[:download_images]
       @fetch_all_image_meta    = options[:fetch_all_image_meta]
+      @image_blacklist_words =  options[:image_blacklist_words]
       @headers            = options[:headers]
       @normalize_url      = options[:normalize_url]
       @faraday_options    = options[:faraday_options]
@@ -39,7 +40,7 @@ module MetaInspector
                                                                 headers:            @headers,
                                                                 faraday_options:    @faraday_options,
                                                                 faraday_http_cache: @faraday_http_cache) unless @document
-      @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images, fetch_all_image_meta: @fetch_all_image_meta)
+      @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images, fetch_all_image_meta: @fetch_all_image_meta, image_blacklist_words: @image_blacklist_words)
     end
 
     extend Forwardable

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -25,6 +25,7 @@ module MetaInspector
 
       @document           = options[:document]
       @download_images    = options[:download_images]
+      @fetch_all_image_meta    = options[:fetch_all_image_meta]
       @headers            = options[:headers]
       @normalize_url      = options[:normalize_url]
       @faraday_options    = options[:faraday_options]
@@ -38,7 +39,7 @@ module MetaInspector
                                                                 headers:            @headers,
                                                                 faraday_options:    @faraday_options,
                                                                 faraday_http_cache: @faraday_http_cache) unless @document
-      @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images)
+      @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images, fetch_all_image_meta: @fetch_all_image_meta)
     end
 
     extend Forwardable

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -25,8 +25,7 @@ module MetaInspector
 
       @document           = options[:document]
       @download_images    = options[:download_images]
-      @fetch_all_image_meta    = options[:fetch_all_image_meta]
-      @image_blacklist_words =  options[:image_blacklist_words]
+      @download_image_options    = options[:download_image_options]
       @headers            = options[:headers]
       @normalize_url      = options[:normalize_url]
       @faraday_options    = options[:faraday_options]
@@ -40,7 +39,7 @@ module MetaInspector
                                                                 headers:            @headers,
                                                                 faraday_options:    @faraday_options,
                                                                 faraday_http_cache: @faraday_http_cache) unless @document
-      @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images, fetch_all_image_meta: @fetch_all_image_meta, image_blacklist_words: @image_blacklist_words)
+      @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images, download_image_options: @download_image_options)
     end
 
     extend Forwardable

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -15,7 +15,8 @@ module MetaInspector
       @links_parser    = MetaInspector::Parsers::LinksParser.new(self)
       @download_images = options[:download_images]
       @fetch_all_image_meta = options[:fetch_all_image_meta]
-      @images_parser   = MetaInspector::Parsers::ImagesParser.new(self, download_images: @download_images, fetch_all_image_meta: @fetch_all_image_meta)
+      @image_blacklist_words =  options[:image_blacklist_words]
+      @images_parser   = MetaInspector::Parsers::ImagesParser.new(self, download_images: @download_images, fetch_all_image_meta: @fetch_all_image_meta, image_blacklist_words: @image_blacklist_words )
       @texts_parser    = MetaInspector::Parsers::TextsParser.new(self)
 
       parsed           # parse early so we can fail early

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -14,7 +14,8 @@ module MetaInspector
       @meta_tag_parser = MetaInspector::Parsers::MetaTagsParser.new(self)
       @links_parser    = MetaInspector::Parsers::LinksParser.new(self)
       @download_images = options[:download_images]
-      @images_parser   = MetaInspector::Parsers::ImagesParser.new(self, download_images: @download_images)
+      @fetch_all_image_meta = options[:fetch_all_image_meta]
+      @images_parser   = MetaInspector::Parsers::ImagesParser.new(self, download_images: @download_images, fetch_all_image_meta: @fetch_all_image_meta)
       @texts_parser    = MetaInspector::Parsers::TextsParser.new(self)
 
       parsed           # parse early so we can fail early

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -14,9 +14,8 @@ module MetaInspector
       @meta_tag_parser = MetaInspector::Parsers::MetaTagsParser.new(self)
       @links_parser    = MetaInspector::Parsers::LinksParser.new(self)
       @download_images = options[:download_images]
-      @fetch_all_image_meta = options[:fetch_all_image_meta]
-      @image_blacklist_words =  options[:image_blacklist_words]
-      @images_parser   = MetaInspector::Parsers::ImagesParser.new(self, download_images: @download_images, fetch_all_image_meta: @fetch_all_image_meta, image_blacklist_words: @image_blacklist_words )
+      @download_image_options = options[:download_image_options]
+      @images_parser   = MetaInspector::Parsers::ImagesParser.new(self, download_images: @download_images, download_image_options: @download_image_options )
       @texts_parser    = MetaInspector::Parsers::TextsParser.new(self)
 
       parsed           # parse early so we can fail early

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -76,6 +76,8 @@ module MetaInspector
            # Remove any urls that have been blacklisted
            imgs_with_size.reject! { |url| @image_blacklist_words.any? { |blacklist_word| url.first.include?(blacklist_word) } }
 
+           # After rejecting blacklisted and duplicated images, only take the first @max_image_downloads if this option is specified.
+           # This can help avoid really long run times in the event there are a huge number of images on the page.
            imgs_with_size = imgs_with_size.first(@max_image_downloads) if @max_image_downloads
 
            if @download_images

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -10,6 +10,7 @@ module MetaInspector
 
       def initialize(main_parser, options = {})
         @download_images = options[:download_images]
+        @fetch_all_image_meta = options[:fetch_all_image_meta]
         super(main_parser)
       end
 
@@ -35,38 +36,46 @@ module MetaInspector
       # Returns an array of [img_url, width, height] sorted by image area (width * height)
       def with_size
         @with_size ||= begin
-          img_nodes = parsed.search('//img').select{ |img_node| img_node['src'] }
-          imgs_with_size = img_nodes.map do |img_node|
-            [URL.absolutify(img_node['src'], base_url, normalize: false), img_node['width'], img_node['height']]
-          end
-          imgs_with_size.uniq! { |url, width, height| url }
-          if @download_images
-            imgs_with_size.map! do |url, width, height|
-              width, height = FastImage.size(url) if width.nil? || height.nil?
-              [url, width.to_i, height.to_i]
-            end
-          else
-            imgs_with_size.map! do |url, width, height|
-              width, height = [0, 0] if width.nil? || height.nil?
-              [url, width.to_i, height.to_i]
-            end
-          end
-          imgs_with_size.sort_by { |url, width, height| -(width.to_i * height.to_i) }
-        end
+           img_nodes = parsed.search('//img') #.select{ |img_node| img_node['src'] }
+
+           imgs_with_size = img_nodes.map do |img_node|
+             if img_node['srcset']
+               img_with_size_from_srcset(img_node)
+             else
+               src_value = img_node.attr('data-src') || img_node.attr('data-image') || img_node.attr('data-img') || img_node.attr('src')
+               if src_value.present?
+                 [URL.absolutify(src_value, base_url, normalize: false), img_node['width'], img_node['height']]
+               end
+             end
+           end.compact
+
+           imgs_with_size.uniq! { |url, width, height| url }
+           if @download_images
+             imgs_with_size.map! do |img_with_size|
+               image_with_meta(img_with_size)
+             end
+           else
+             imgs_with_size.map! do |url, width, height|
+               width, height = [0, 0] if width.nil? || height.nil?
+               [url, width.to_i, height.to_i]
+             end
+           end
+           imgs_with_size.sort_by { |url, width, height| -(width.to_i * height.to_i) }
+         end
       end
 
       # Returns the largest image from the image collection,
       # filtered for images that are more square than 10:1 or 1:10
       def largest
         @largest_image ||= begin
-          imgs_with_size = with_size.dup
-          imgs_with_size.keep_if do |url, width, height|
-            ratio = width.to_f / height.to_f
-            ratio > 0.1 && ratio < 10
-          end
-          url, width, height = imgs_with_size.first
-          url
-        end
+                             imgs_with_size = with_size.dup
+                             imgs_with_size.keep_if do |url, width, height|
+                               ratio = width.to_f / height.to_f
+                               ratio > 0.1 && ratio < 10
+                             end
+                             url, width, height = imgs_with_size.first
+                             url
+                           end
       end
 
       # Return favicon url if exist
@@ -79,6 +88,35 @@ module MetaInspector
       end
 
       private
+
+      def image_with_meta(img_with_size)
+        url, width, height  = img_with_size
+        file_type = nil
+        file_size = nil
+
+        if @fetch_all_image_meta
+          # Fetch everything, dimensions, size, type
+          fast_img = FastImage.new(url)
+          width, height = fast_img.size
+          file_type = fast_img.type
+          file_size = fast_img.content_length
+        else
+          # Only fetch size if you haven't detected it yet
+          width, height = FastImage.size(url) if width.nil? || height.nil?
+        end
+        [url, width.to_i, height.to_i, file_type, file_size]
+      end
+
+      # Analyze the srcset and attempt to choose the largest image from it.
+      def img_with_size_from_srcset(srcset_img)
+        srcset_values = srcset_img['srcset']&.split(',')
+        largest_src = Array.wrap(srcset_values).map do |srcset_value|
+          srcset_value_img_props = srcset_value.split
+          { url: srcset_value_img_props.first, size: srcset_value_img_props.last.to_i }
+        end.sort_by { |v| -v[:size] }.first.dig(:url)
+        return unless largest_src.present?
+        [URL.absolutify(largest_src.strip, base_url, normalize: false), 0, 0]
+      end
 
       def images_collection
         @images_collection ||= absolutified_images

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -68,14 +68,14 @@ module MetaInspector
       # filtered for images that are more square than 10:1 or 1:10
       def largest
         @largest_image ||= begin
-                             imgs_with_size = with_size.dup
-                             imgs_with_size.keep_if do |url, width, height|
-                               ratio = width.to_f / height.to_f
-                               ratio > 0.1 && ratio < 10
-                             end
-                             url, width, height = imgs_with_size.first
-                             url
-                           end
+          imgs_with_size = with_size.dup
+          imgs_with_size.keep_if do |url, width, height|
+            ratio = width.to_f / height.to_f
+            ratio > 0.1 && ratio < 10
+          end
+          url, width, height = imgs_with_size.first
+          url
+        end
       end
 
       # Return favicon url if exist

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -75,7 +75,7 @@ module MetaInspector
            imgs_with_size.uniq! { |url, width, height| url }
 
            # Remove any urls that have been blacklisted
-           imgs_with_size.reject! { |url| @image_blacklist_words.any? { |blacklist_word| url.first.include?(blacklist_word) } }
+           imgs_with_size.reject! { |url| @image_blacklist_words.any? { |blacklist_word| url&.first.nil? || url.first.include?(blacklist_word) } }
 
            # After rejecting blacklisted and duplicated images, only take the first @max_image_downloads if this option is specified.
            # This can help avoid really long run times in the event there are a huge number of images on the page.

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -157,7 +157,7 @@ module MetaInspector
         largest_src = Array.wrap(srcset_values).map do |srcset_value|
           srcset_value_img_props = srcset_value.split
           { url: srcset_value_img_props.first, size: srcset_value_img_props.last.to_i }
-        end.sort_by { |v| -v[:size] }.first.dig(:url)
+        end.sort_by { |v| -v[:size] }.first&.dig(:url)
         return unless largest_src.present?
         [URL.absolutify(largest_src.strip, base_url, normalize: false), 0, 0]
       end

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -139,6 +139,10 @@ module MetaInspector
         imgs += parsed_document.xpath("//@data-bg|//@data-background").map do |data_bg|
           [URL.absolutify(data_bg.value&.strip, base_url, normalize: false), 0, 0] if data_bg.try(:value).present?
         end
+
+        # As a fallback look for anything that looks like an image url.  This will help detect images that are stored in json on the page and then redered with js later.
+        imgs += parsed_document.to_html.scan(/(http?s?:?\/\/[^"']*\.(?:png|jpg|jpeg|png))/i)
+
         imgs
       end
 

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -63,7 +63,7 @@ module MetaInspector
              else
                src_value = img_node.attr('data-src') || img_node.attr('data-image') || img_node.attr('data-img') || img_node.attr('src')
                if src_value.present?
-                 [URL.absolutify(src_value, base_url, normalize: false), img_node['width'], img_node['height']]
+                 [URL.absolutify(src_value.strip, base_url, normalize: false), img_node['width'], img_node['height']]
                end
              end
            end
@@ -71,6 +71,7 @@ module MetaInspector
            imgs_with_size += bg_and_other_imgs(parsed)
 
            imgs_with_size.compact!
+
            imgs_with_size.uniq! { |url, width, height| url }
 
            # Remove any urls that have been blacklisted

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -3,6 +3,8 @@ require 'fastimage'
 module MetaInspector
   module Parsers
     class ImagesParser < Base
+      DEFAULT_IMG_BLACKLIST =  ['.woff', '.font', '.tiff', '.tif', 'data:'].freeze
+
       delegate [:parsed, :meta, :base_url]         => :@main_parser
       delegate [:each, :length, :size, :[], :last] => :images_collection
 
@@ -11,6 +13,7 @@ module MetaInspector
       def initialize(main_parser, options = {})
         @download_images = options[:download_images]
         @fetch_all_image_meta = options[:fetch_all_image_meta]
+        @image_blacklist_words =  options[:image_blacklist_words] || DEFAULT_IMG_BLACKLIST
         super(main_parser)
       end
 
@@ -53,6 +56,9 @@ module MetaInspector
 
            imgs_with_size.compact!
            imgs_with_size.uniq! { |url, width, height| url }
+
+           # Remove any urls that have been blacklisted
+           imgs_with_size.reject! { |url| @image_blacklist_words.any? { |blacklist_word| url.first.include?(blacklist_word) } }
 
            if @download_images
              imgs_with_size.map! do |img_with_size|

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -126,7 +126,7 @@ module MetaInspector
         imgs = []
         # Find any css bg images
         imgs += parsed_document.to_html.scan(/\burl\s*\(\s*["']?([^"'\r\n\)\(]+)["']?\s*\)/).map do |background_image_url|
-          [URL.absolutify(background_image_url&.strip, base_url, normalize: false), 0, 0]
+          [URL.absolutify(background_image_url.first&.strip, base_url, normalize: false), 0, 0]
         end
 
         # Find any elements that have bg or background data attributes

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -89,7 +89,6 @@ module MetaInspector
                  valid
                end
              end
-             imgs_with_size
            else
              imgs_with_size.map! do |url, width, height|
                width, height = [0, 0] if width.nil? || height.nil?

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -174,8 +174,9 @@ module MetaInspector
         end
 
         # As a fallback look for anything that looks like an image url.  This will help detect images that are stored in json on the page and then redered with js later.
-        imgs += parsed_document.to_html.scan(/http?s?:?\/\/[^"']*\.(?:png|jpg|jpeg|png)/i).map do |url|
-          [url.strip, 0, 0] if url.present?
+        imgs += parsed_document.to_html.scan(/\/[^"']*\.(?:png|jpg|jpeg|png)/i).map do |url|
+          absolutified_url = URL.absolutify(url.strip, base_url, normalize: false)
+          [absolutified_url, 0, 0] if absolutified_url.present?
         end
 
         imgs


### PR DESCRIPTION
Looking for an early review as I continue to improve on this.

Addresses:
https://github.com/metainspector/metainspector/issues/269 - Adding ability to scrape non standard images srcset, data-src, data-bg, and images in json that are rendered via js. 

https://github.com/metainspector/metainspector/issues/268 - provide an option to return additional meta info about each image that is collected with FastImage anyway.  This includes, file type, and file size.

https://github.com/metainspector/metainspector/issues/271 - If download_images is enabled, we can use FastImage to detect whether the owner_suggested image is valid.  