### PR TITLE
Allow configuration of net-http options

### DIFF
--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -59,6 +59,7 @@ module MetaInspector
       Timeout::timeout(fatal_timeout) do
         @faraday_options.merge!(:url => url)
         follow_redirects_options = @faraday_options.delete(:redirect) || {}
+        adapter_options = @faraday_options.delete(:adapter_options) || {}
 
         session = Faraday.new(@faraday_options) do |faraday|
           faraday.request :retry, max: @retries
@@ -78,7 +79,11 @@ module MetaInspector
 
           faraday.headers.merge!(@headers || {})
           faraday.response :encoding
-          faraday.adapter :net_http
+          faraday.adapter :net_http do |http|
+            adapter_options.each do |key, value|
+              http.public_send("#{key}=", value)
+            end
+          end
         end
 
         response = session.get do |req|


### PR DESCRIPTION
Hello.

I added an option to configure the net-http adapter. Some websites throw a `dh key too small` error, which is the same as described in https://github.com/lostisland/faraday-net_http/pull/4. With this PR, you can fix it like this:

```ruby
MetaInspector.new(url, faraday_options: {adapter_options: {ciphers: "DEFAULT:!DH"}}})
```

I've also tried using `ssl: { verify: false }`, but it didn't work.

Thanks for this project.